### PR TITLE
Give Version a to_s method

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -165,4 +165,8 @@ class Version < ApplicationRecord
   end
 
 
+  def to_s
+    "#{self.number}"
+  end
+
 end

--- a/app/views/morning_mailer/morning_email.html.erb
+++ b/app/views/morning_mailer/morning_email.html.erb
@@ -1,14 +1,14 @@
 <% unless @failing_versions.empty? %>
   <p>
     The following <samp>MESA</samp> revision(s) have had failing test cases 
-    in the last 24 hours: <%= @failing_versions.map(&:number).map(&:to_s).join(', ') %>.
+    in the last 24 hours: <%= @failing_versions.map(&:to_s).join(', ') %>.
   </p>
 <% end %>
 <% unless @passing_versions.empty? %>
   <p>
       The following <samp>MESA</samp> revision(s) have passed all test cases
       submitted for them in the last 24 hours: 
-      <%= @passing_versions.map(&:number).map(&:to_s).join(', ') %>.
+      <%= @passing_versions.map(&:to_s).join(', ') %>.
   </p>
 <% end %>
 
@@ -31,7 +31,7 @@
   <% @failing_versions.each do |version| %>
     <h3>
       <a clicktracking=off href=<%= @version_links[version] %>>
-        <%= version.number %>
+        <%= version %>
       </a>
     </h3>
     <ul>

--- a/app/views/morning_mailer/morning_email.text.erb
+++ b/app/views/morning_mailer/morning_email.text.erb
@@ -1,9 +1,9 @@
 <% unless @failing_versions.empty? %>
-The following revision(s) have had failing test cases in the last 24 hours: <%= @failing_versions.map(&:number).map(&:to_s).join(', ') %>.
+The following revision(s) have had failing test cases in the last 24 hours: <%= @failing_versions.map(&:to_s).join(', ') %>.
 <% end %>
 
 <% unless @passing_versions.empty? %>
-The following revision(s) have passed all test cases submitted for them in the last 24 hours: <%= @passing_versions.map(&:number).map(&:to_s).join(', ') %>.
+The following revision(s) have passed all test cases submitted for them in the last 24 hours: <%= @passing_versions.map(&:to_s).join(', ') %>.
 <% end %>
 
 <% if @passing_versions.empty? && @failing_versions.empty? %>
@@ -12,7 +12,7 @@ No tests were run in the last 24 hours. This e-mail serves to let you know that 
 Below is a summary of the failing test cases. Visit <%= @root_url %> for more details.
 
 <% @failing_versions.each do |version| %>
-<%= version.number %>
+<%= version %>
 ==============================
 <% @cases[version].each do |test_case| %>
 - <%= test_case.name %>


### PR DESCRIPTION
I think this should fix the issue with morning mailing subjects looking like "Failing tests in revision #<Version:0x000000000630b4d8>".

I did a little (untested) simplification too, so if you'd prefer to fix this in a different way (i.e. just add .number when the subject is constructed), feel free to decline this PR.