### PR TITLE
Phase 3: performance and bug fixes (perf-github-sync)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,10 +41,12 @@ that makes the change.
   from the original plan — Rack 3's `:unprocessable_entity` →
   `:unprocessable_content` rename, `show_exceptions` becoming an enum,
   and the gems that needed bumps or removal for the resolver to settle.
-- **The test suite is small but real.** 24 request specs cover auth,
-  submissions API, GitHub webhook, and high-traffic page renders. They are
-  the regression safety net for upcoming Rails upgrade work. Build on this
-  rather than starting fresh.
+- **The test suite is small but real.** 78 specs (request + model + job)
+  cover auth, submissions API, GitHub webhook (now async via
+  `BranchSyncJob`), branch deletion, the Octokit middleware wiring,
+  `TestInstance.query`, `Commit#computer_info`, and high-traffic page
+  renders. They are the regression safety net for upcoming work — build
+  on this rather than starting fresh.
 - **No Cucumber.** The old Cucumber suite is preserved at
   `features.deprecated/` and `spec/features.deprecated/`. RSpec request
   specs replace it. Do not add `.feature` files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,10 @@ Before doing non-trivial work, read the appropriate doc:
   Rails 6.1 → 8.0 upgrade (now complete on the `rails-upgrade` branch),
   including the deviations from the original phased plan that actually
   needed code changes.
+- **[`docs/sync-overhaul.md`](docs/sync-overhaul.md)** — plan for the
+  Phase 3.5 GitHub sync rewrite (topology-driven ordering, webhook
+  payload-driven sync). Spans multiple sessions on the
+  `perf-sync-topology` branch (not yet created).
 
 When changes invalidate the plan, update the relevant doc in the same commit
 that makes the change.

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'rails-html-sanitizer', '~> 1.6.2'
 gem 'font-awesome-rails'
 
 # Git stuff
-gem 'octokit', "~> 4.0"
+gem 'octokit', '~> 10.0'
 gem 'faraday-http-cache'
 gem 'faraday-retry'
 gem 'github_webhook', '~> 1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       logger
     faraday-http-cache (2.5.0)
       faraday (>= 0.8)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
@@ -262,7 +262,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
-    octokit (4.25.1)
+    octokit (10.0.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pg (1.5.4)
@@ -364,7 +364,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sawyer (0.9.2)
+    sawyer (0.9.3)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     securerandom (0.4.1)
@@ -454,7 +454,7 @@ DEPENDENCIES
   msgpack (~> 1.7)
   net-imap (>= 0.5.7)
   nokogiri (>= 1.18.9)
-  octokit (~> 4.0)
+  octokit (~> 10.0)
   pg
   puma (>= 6.4.2)
   puma_worker_killer

--- a/app/controllers/github_webhooks_controller.rb
+++ b/app/controllers/github_webhooks_controller.rb
@@ -4,11 +4,11 @@ class GithubWebhooksController < ApplicationController
 
   include GithubWebhook::Processor
 
-  # Handle push event
+  # Handle push event by kicking off a background sync. Returning quickly
+  # matters: GitHub considers a webhook delivery failed after 10 seconds,
+  # and the inline sync can take much longer than that on a large push.
   def github_push(payload)
-    # Create new entry in database for each new commit in push
-    # Commit.push_update(payload)
-    Branch.api_update_branches
+    BranchSyncJob.perform_later
   end
 
   private

--- a/app/jobs/branch_sync_job.rb
+++ b/app/jobs/branch_sync_job.rb
@@ -1,0 +1,11 @@
+class BranchSyncJob < ApplicationJob
+  queue_as :default
+
+  # Webhooks fire BranchSyncJob to keep the controller off the GitHub API
+  # critical path. The job itself runs Branch.api_update_branches, which
+  # is idempotent — running it twice produces the same end state — so we
+  # don't bother deduplicating overlapping enqueues at this layer.
+  def perform
+    Branch.api_update_branches
+  end
+end

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -109,65 +109,16 @@ class Branch < ApplicationRecord
     ########################################
     ### STEP 3: DELETE ORPHANED BRANCHES ###
     ########################################
+    # Drop memberships before the branches so the unguarded branch_id FK
+    # column doesn't end up pointing at non-existent branches. Orphaned
+    # commits are picked up by the db:cleanup_orphaned_commits rake task.
     to_delete = Branch.where(name: existing_branch_names - github_branch_names)
+    return if to_delete.empty?
 
-    # Simplified approach: just delete branch memberships and then branches
-    # We'll handle orphaned commits in a separate weekly task
-    unless to_delete.empty?
-      # First delete all branch memberships for these branches
+    Branch.transaction do
       BranchMembership.where(branch_id: to_delete.pluck(:id)).delete_all
-      
-      # Then delete the branches themselves
       to_delete.delete_all
     end
-    return nil
-
-    # ### BEGIN ORIGINAL CODE
-    # # TODO: SOMETHING BAD IS HAPPENING HERE. LOTS OF MEMORY GETS USED UP WHEN
-    # # DELETING MERGED BRANCHES.
-    # # identify branches to be destroyed (exist in db, but not on GitHub)
-    # to_delete = Branch.includes(:head).
-    #   where(name: existing_branch_names - github_branch_names).to_a
-
-    # # IS THE STEP BELOW NEEDED? I SUSPECT THIS IS WHERE THE MEMORY LEAK HAPPENS
-    # # this looks at branches that are not to be deleted that also contain this
-    # # [doomed] branch's head commit. The thinking is that if those branches
-    # # contain this branch's head commit then it should have all of this branch's
-    # # commits
-
-    # # final check on head commits of orphaned branches. To make sure none of
-    # # their commits got abandoned too far in the past. Hopefully the head
-    # # commits of abandoned branches made it into their new homes, and then we
-    # # can make sure that subsequent commits did as well.
-    # to_delete.each do |branch|
-    #   branch.head.branches.reject { |b| to_delete.include? b }.each do |other_branch|
-    #     in_both = other_branch.commits.where(id: branch.commits.pluck(:id))
-
-    #     # nuclear option. If we're missing commits in the new branches, it's
-    #     # not clear where they should be. Just look up ALL commits in the
-    #     # branch and reorder them. The commits must already exist in the
-    #     # database; we just need to order them. This is bad since it makes
-    #     # tons of api calls, especially as the repo grows.
-    #     other_branch.api_reorder_all_commits if in_both.count < branch.commits.count
-    #   end
-    # end
-
-    # # all orphaned commits should now be properly situated in new branches. Now
-    # # we kill off the defunct memberships, and finally, the defunct branches.
-    # # Using destroy_all would be simpler, but much more time-consuming, as
-    # # it would need to issue a delete statement for each affected branch
-    # # membership. Instead, we delete the branch memberships first, and then
-    # # kill the branches themselves with delete_all, which is closer to the
-    # # database, and requires more babysitting (branch memberships are dependent
-    # # on branches, so they should die when the branch dies)
-    # unless to_delete.empty?
-    #   to_delete.each do |branch|
-    #     branch.branch_memberships.delete_all
-    #     branch.destroy
-    #   end
-    # end
-
-    # nil
   end
 
   # brings commits in a branch and their order up to date by syncing order

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -427,6 +427,10 @@ class Branch < ApplicationRecord
     return tccs unless this_membership
 
     position = this_membership.position
+    # Memberships ingested before positions were back-filled have nil here;
+    # without this guard `position + 1` and `0...position` raise and the
+    # test_case_commits#show page breaks.
+    return tccs if position.nil?
 
     # find "older" commits in the branch, and count how many we can expect to
     # have this test case represented in them (don't want to search forever

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -428,11 +428,15 @@ class Commit < ApplicationRecord
       end
       return nil
     else
-      # first check main, since it should have highest priority
-      main_candidate = self.test_candidate(computer: computer,
-        allow_optional: allow_optional, allow_fpe: allow_fpe,
-        allow_skip: allow_skip, max_age: max_age, branch: Branch.main)
-      return main_candidate if main_candidate
+      # first check main, since it should have highest priority. Skip if
+      # there's no main branch yet (without this guard, recursing with
+      # branch: nil would re-enter the else branch and spin forever).
+      if Branch.main
+        main_candidate = self.test_candidate(computer: computer,
+          allow_optional: allow_optional, allow_fpe: allow_fpe,
+          allow_skip: allow_skip, max_age: max_age, branch: Branch.main)
+        return main_candidate if main_candidate
+      end
 
       # no matching candidates in main? Check elsewhere. Same as
       # search on specific branch, but we search on all commits (definite
@@ -455,9 +459,6 @@ class Commit < ApplicationRecord
         # make sure commit still lives in a branch
         next if commit.branches.count.zero?
         if Submission.where(commit: commit, computer: computer).count.zero?
-          puts "Found the candidate in other branches."
-          puts "Total submissions:"
-          puts Submissions.where(commit: commit, computer: computer).count
           return commit
         end
       end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -543,40 +543,57 @@ class Commit < ApplicationRecord
   end
 
   def computer_info
-    # special call that collects a version's test instances and groups them
-    # by unique combinations of computer and computer specificaiton, and
-    # ONLY gathers that information
-    subs = submissions.select('computer_id, platform_version, sdk_version, '\
-      'math_backend, compiler, compiler_version').group(
-      'computer_id, platform_version, sdk_version, math_backend, compiler, '\
-      'compiler_version')
-    specs = []
-    subs.each do |sub|
-      new_entry = {}
-      new_entry[:computer] = Computer.includes(:user).find(sub.computer_id)
-      new_entry[:spec] = sub.computer_specification
-      new_entry[:numerator] = test_instances.where(
-        computer_id: sub.computer_id,
-        computer_specification: sub.computer_specification
-      ).pluck(:test_case_id).uniq.count
-      new_entry[:denominator] = test_cases.count
-      new_entry[:frac] = new_entry[:numerator].to_f /
-                         new_entry[:denominator].to_f
-      compilation_stati = submissions.where(
-        computer: new_entry[:computer]
-      ).pluck(:compiled).uniq.reject(&:nil?)
-      new_entry[:compilation] = case compilation_stati.count
-                                when 0
-                                  :unknown
-                                when 1
-                                  compilation_stati[0] ? :success : :failure
-                                else
-                                  :mixed
-                                end
-      specs << new_entry
+    # One row per unique combination of (computer_id, platform_version,
+    # sdk_version, math_backend, compiler, compiler_version). The view at
+    # commits/show.html.haml iterates these and reads :computer (+ .user),
+    # :spec, :numerator, :denominator, :frac, :compilation — keep all of
+    # those keys populated.
+    all_subs = submissions.includes(computer: :user).to_a
+    return [] if all_subs.empty?
 
+    grouped = all_subs.group_by do |sub|
+      [sub.computer_id, sub.platform_version, sub.sdk_version,
+       sub.math_backend, sub.compiler, sub.compiler_version]
     end
-    specs
+
+    # Per-(computer, spec) distinct test_case_id counts in one query.
+    ti_counts = test_instances
+                .group(:computer_id, :computer_specification)
+                .distinct
+                .count(:test_case_id)
+
+    # Compilation status is rolled up per computer (not per spec): if any
+    # of this computer's submissions disagree on `compiled`, every spec
+    # entry for that computer reports :mixed.
+    compile_stati_by_computer = all_subs.group_by(&:computer_id)
+                                        .transform_values do |subs|
+      subs.map(&:compiled).uniq.reject(&:nil?)
+    end
+
+    denominator = test_cases.count
+
+    grouped.map do |_key, subs|
+      sub = subs.first
+      computer = sub.computer
+      spec = sub.computer_specification
+      numerator = ti_counts[[sub.computer_id, spec]] || 0
+      stati = compile_stati_by_computer[sub.computer_id] || []
+
+      compilation = case stati.count
+                    when 0 then :unknown
+                    when 1 then stati[0] ? :success : :failure
+                    else :mixed
+                    end
+
+      {
+        computer: computer,
+        spec: spec,
+        numerator: numerator,
+        denominator: denominator,
+        frac: denominator.zero? ? 0.0 : numerator.to_f / denominator.to_f,
+        compilation: compilation
+      }
+    end
   end
 
   # note: future optimization would be to make these three "questions" be
@@ -663,7 +680,14 @@ class Commit < ApplicationRecord
                   end
   end
 
-  # 
+  # commits/show calls compilation_status, compile_success_count, and
+  # compile_fail_count back-to-back; cache the single query they all share
+  # so the page does one SELECT instead of three.
+  def compile_stati
+    @compile_stati ||= submissions.pluck(:compiled)
+  end
+
+  #
   # Guide: nil = untested (or unreported)
   #          -1 = no compilation status provided
   #          0  = compiles on all systems so far
@@ -672,31 +696,18 @@ class Commit < ApplicationRecord
   # this method just keeps this scheme logically consistent when a new report
   # rolls in, but it DOES NOT save the result to the database.
   def compilation_status
-    compile_stati = submissions.pluck(:compiled).reject(&:nil?)
-    if compile_stati.empty?
-      # no submissions
-      return -1
-    else
-      if compile_stati.uniq.count > 1
-        # multiple values; mixed results
-        return 2
-      else
-        if compile_stati[0]
-          # first one (and thus all) is true, all passing!
-          return 0
-        else
-          return 1
-        end
-      end
-    end
+    stati = compile_stati.reject(&:nil?)
+    return -1 if stati.empty?
+    return 2  if stati.uniq.count > 1
+    stati.first ? 0 : 1
   end
 
   def compile_success_count
-    submissions.pluck(:compiled).count(true)
+    compile_stati.count(true)
   end
 
   def compile_fail_count
-    submissions.pluck(:compiled).count(false)
+    compile_stati.count(false)
   end
 
   # branches that this commit is NOT in, in two categories:

--- a/app/models/test_instance.rb
+++ b/app/models/test_instance.rb
@@ -373,6 +373,8 @@ class TestInstance < ApplicationRecord
     # split on colons, but note that the divider separates keys from values,
     # and not key-value pairs from each other. So we will have an array that
     # looks like [key1, val1 key2, val2 key3, ... valn-1 keyn, valn]
+    return {} if query_text.nil? || query_text.strip.empty?
+
     split_up = query_text.split(':')
 
     # first key is trivial
@@ -424,9 +426,13 @@ class TestInstance < ApplicationRecord
       SearchOption.new('re_RAM', self, :mem_re, true) do |mem_GB|
         mem_GB.to_f * (1024**2)
       end,
-      # runtimes now in minutes. Meaning less clear as this is reported by
-      # test cases themselves
-      SearchOption.new('runtime', self, :total_runtime_minutes, true),
+      # `total_runtime_seconds` is the column; users enter minutes (or
+      # natural phrasings like "1 hr 30 min") and parse_runtime converts
+      # to seconds. There is no total_runtime_minutes column — relying on
+      # the like-named instance method would break inside a where clause.
+      SearchOption.new('runtime', self, :total_runtime_seconds, true) do |runtime_str|
+        TestInstance.parse_runtime(runtime_str)
+      end,
       SearchOption.new('date', self, :created_at, true) do |datestring|
         Date.parse(datestring)
       end,
@@ -475,23 +481,22 @@ class TestInstance < ApplicationRecord
     # obliterate ill-formed search keys
     failed_requirements.each {|key| query_hash.delete(key) }
 
-    puts '#########################'
-    puts 'query:'
-    puts query_hash
-    puts '#########################'
-    
     # now have key-value pairs, values may be ranges. Reach out to each
     # SearchOption to actually get query, and shove each into a where call.
     # ActiveRecord is lazy and will compress these all into a single search
     # when it is needed.
     query_hash.each_pair do |key, value|
-      res = res.where(options_hash[key].query_piece(value))
-      puts "adding to query:"
-      puts options_hash[key].query_piece(value)
+      begin
+        res = res.where(options_hash[key].query_piece(value))
+      rescue Date::Error, ArgumentError, TypeError
+        # The user typed something the preprocessor can't parse (most
+        # commonly a malformed date/datetime). Treat it like an unknown
+        # key — drop it from the query and report it back to the view.
+        failed_requirements << "#{key} (#{value.inspect})"
+      end
     end
 
     res = res.where.not(commit_id: nil)
-    # res
     return [res.includes(:test_case, :test_case_commit, :commit, computer: :user).
       order('commits.commit_time DESC, test_instances.created_at DESC'), failed_requirements]
   end

--- a/app/views/commits/_commit.json.jbuilder
+++ b/app/views/commits/_commit.json.jbuilder
@@ -2,4 +2,8 @@ json.extract! commit, :id, :sha, :author, :author_email, :message,
               :commit_time, :created_at, :updated_at, :passed_count,
               :failed_count, :mixed_count, :untested_count, :checksum_count,
               :computer_count, :complete_computer_count, :status
-json.url commit_url(commit.branches[0], commit, format: json)
+
+branch = commit.branches.first
+if branch
+  json.url commit_url(branch.name, commit.short_sha, format: :json)
+end

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -94,21 +94,14 @@ Known issues to address:
   Commit relationships. Reproduce, fix, add a regression spec.
 - **General N+1 audit on the commit show page** — large commits with many
   test cases / instances likely have hot query patterns worth addressing.
-- **Upgrade Octokit 4 → 10.** The Gemfile is pinned at `octokit '~> 4.0'`;
-  the current major is 10.x. octokit 5 changed the Faraday middleware
-  contract that [`app/models/application_record.rb`](app/models/application_record.rb)
-  configures directly (`Faraday::RackBuilder.new { ... }` plus the
-  `Octokit::Response::RaiseError` middleware and the explicit
-  `Octokit.middleware = stack` assignment), so this is not a drop-in
-  bump. Worth doing here because (a) this phase already requires
-  touching the GitHub sync code, (b) the app leans hard on the GitHub
-  API for commits/branches/webhooks and being five majors behind on
-  the client library is a real maintenance and security concern, and
-  (c) any background-job refactor of the sync flow benefits from the
-  newer Faraday connection-pooling and retry semantics. Plan to test
-  the middleware stack and rate-limit/retry behavior carefully — the
-  webhook spec covers the controller wiring but nothing covers the
-  outbound API calls.
+- ~~**Upgrade Octokit 4 → 10.**~~ Done. Drop-in bump — the
+  middleware-contract concern in the original plan turned out to be
+  unfounded; the current Octokit README still shows the exact
+  `Octokit.middleware = stack` pattern that
+  [`app/models/application_record.rb`](app/models/application_record.rb)
+  uses, and none of the breaking changes in 5/6/7/8/9/10 touch the
+  endpoints this app calls. Backed by a new wiring spec at
+  [`spec/models/github_api_wiring_spec.rb`](spec/models/github_api_wiring_spec.rb).
 
 Doing this after the upgrade gives access to Rails 7.1's async query loading
 and improved background-job tooling.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -80,7 +80,7 @@ _Coffee-rails risk was eliminated by completing Phase 1.5 first._
 ## Phase 3 — Performance and bug fixes
 
 **Branch:** `perf-github-sync`
-**Status:** not started
+**Status:** in progress
 **Estimate:** 2–3 days
 
 Known issues to address:
@@ -174,19 +174,18 @@ Add items here as they come up so they don't get lost.
 
 - _(none yet — placeholder for future work)_
 
-## Bugs surfaced by Phase 1 specs (queued for Phase 3)
+## Bugs surfaced by Phase 1 specs (fixed in Phase 3)
 
-- `Commit.test_candidate` infinite-recurses when `Branch.main` returns nil
-  (`app/models/commit.rb:432`). The spec currently stubs it; the real fix
-  is to guard the recursive call.
-- `app/views/commits/_commit.json.jbuilder:5` calls
-  `commit_url(commit.branches[0], ...)` — if a commit has no branches yet,
-  this raises a route-generation error. The submissions API hits this on
-  empty submissions for newly-ingested commits.
-- `BranchMembership.position` can be nil, but `Branch#nearby_test_case_commits`
-  ([`app/models/branch.rb:451`](app/models/branch.rb:451)) calls `position + 1`
-  without a nil check, breaking the `test_case_commits#show` page for those
-  memberships.
+All three landed at the head of the `perf-github-sync` branch, each with a
+regression spec:
+
+- `Commit.test_candidate` no longer infinite-recurses when `Branch.main` is
+  nil. Drive-by: removed three stale debug `puts`, one of which referenced
+  an undefined `Submissions` constant and crashed the fallback path.
+- `_commit.json.jbuilder` now skips the `url` field when a commit has no
+  branch memberships yet, instead of raising on `commit_url(nil, ...)`.
+- `Branch#nearby_test_case_commits` returns just the seed TCC when the
+  membership has a `nil` position, instead of raising on `position + 1`.
 
 ## Bugs/UX issues surfaced during Phase 1.5 smoke testing
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -185,10 +185,13 @@ regression spec:
 All preexisting (present on Heroku too); not regressions from the JS
 conversion. Captured here so they don't get lost.
 
-- **`test_instances#search` is broken.** Owner reports the feature itself
-  doesn't work, independent of JS. Phase 3 candidate; needs investigation
-  to figure out whether the controller logic, the search form, or the
-  results rendering is at fault.
+- ~~**`test_instances#search` is broken.**~~ Fixed in Phase 3. Four bugs
+  in `TestInstance.query`: empty input raised `NoMethodError`, the
+  `runtime` option pointed at a non-existent column, and bad date /
+  datetime values crashed instead of going on the failures list. The
+  documented `version` option is still commented out in the model
+  (no `mesa_version` column exists any more) — the help text should
+  drop that bullet during Phase 4.
 - **Column visibility on `test_case_commits#show` does not persist across
   reloads.** The JS writes a cookie when a column is toggled, but on next
   load the columns reset to the default set. Either the cookie name doesn't

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -80,7 +80,7 @@ _Coffee-rails risk was eliminated by completing Phase 1.5 first._
 ## Phase 3 — Performance and bug fixes
 
 **Branch:** `perf-github-sync`
-**Status:** in progress
+**Status:** complete
 **Estimate:** 2–3 days
 
 Known issues to address:
@@ -93,8 +93,13 @@ Known issues to address:
   `Branch.api_update_branches`'s deletion path is now wrapped in a
   transaction and covered by seven regression specs; the
   cascading-delete hypothesis didn't reproduce in any scenario.
-- **General N+1 audit on the commit show page** — large commits with many
-  test cases / instances likely have hot query patterns worth addressing.
+- ~~**General N+1 audit on the commit show page**~~ Done. `Commit#computer_info`
+  was doing ~4 queries per unique spec on commits/show — rewritten to batch
+  the lookups, plus `compile_stati` is now memoized so the
+  `compilation_status` / `compile_success_count` / `compile_fail_count`
+  trio that the show action calls back-to-back hits the database once
+  instead of three times. Behavior + query-count regression specs at
+  [`spec/models/commit_computer_info_spec.rb`](spec/models/commit_computer_info_spec.rb).
 - ~~**Upgrade Octokit 4 → 10.**~~ Done. Drop-in bump — the
   middleware-contract concern in the original plan turned out to be
   unfounded; the current Octokit README still shows the exact
@@ -213,6 +218,14 @@ conversion. Captured here so they don't get lost.
 
 ## Done
 
+- **Performance and bug fixes** (Phase 3). Fifteen commits on the
+  `perf-github-sync` branch covering the four roadmap items plus four
+  queued bugs: the three Phase-1-spec-discovered bugs (test_candidate
+  recursion, jbuilder branchless crash, branch nearby_test_case_commits
+  nil position), the test_instances#search regression suite, the
+  branch-deletion regression specs, Octokit 4 → 10, the webhook → ActiveJob
+  cut-over, and the commits#show N+1 elimination. Suite grew from 24 to
+  78 specs.
 - **Rails 6.1 → 8.0 upgrade** (Phase 2). Eight commits on the
   `rails-upgrade` branch: Phase 0 (`update_attributes` → `update`),
   Phases 1–3 (flip `load_defaults` 5.1 → 5.2 → 6.0 → 6.1), Phase 4

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -112,6 +112,28 @@ Known issues to address:
 Doing this after the upgrade gives access to Rails 7.1's async query loading
 and improved background-job tooling.
 
+## Phase 3.5 — GitHub sync overhaul
+
+**Branch:** `perf-sync-topology` (not yet created)
+**Status:** planned
+**Estimate:** 4–6 days
+
+See [`docs/sync-overhaul.md`](sync-overhaul.md) for the full plan.
+
+The Phase 3 sync work moved the GitHub fan-out off the webhook request
+path but didn't reduce the underlying API-call count. This phase replaces
+the position-based ordering scheme with a stored commit topology
+(`commit_relations` join table) and rewrites the sync flow to consume the
+webhook payload + `compare(before, after)` directly. Outcomes:
+
+- Commit ordering on each branch matches what
+  `github.com/MESAHub/mesa/commits/{branch}` shows.
+- Typical-push sync cost drops from "100+ commits fetched and
+  repositioned per branch + 4 content calls per new commit" to
+  "zero or one API call."
+- `branch_memberships.position` is retired; ordering comes from a
+  recursive CTE over `commit_time`.
+
 ## Phase 4 — Frontend modernization
 
 **Branch:** `frontend-tailwind`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -85,13 +85,14 @@ _Coffee-rails risk was eliminated by completing Phase 1.5 first._
 
 Known issues to address:
 
-- **GitHub sync after every webhook push is slow.** The current
-  `GithubWebhooksController` flow synchronizes commit/branch state inline.
-  Move to background jobs (ActiveJob), batch where possible, and skip
-  redundant fetches.
-- **Deleting branches from GitHub causes errors.** Likely a cascading-delete
-  or missing-`dependent`-option issue on the Branch ↔ BranchMembership ↔
-  Commit relationships. Reproduce, fix, add a regression spec.
+- ~~**GitHub sync after every webhook push is slow.**~~ Done. The webhook
+  now enqueues a `BranchSyncJob` and returns immediately. ActiveJob's
+  default `:async` adapter is fine for this scale; swap in Solid Queue
+  later if the queue needs durability.
+- ~~**Deleting branches from GitHub causes errors.**~~ Done.
+  `Branch.api_update_branches`'s deletion path is now wrapped in a
+  transaction and covered by seven regression specs; the
+  cascading-delete hypothesis didn't reproduce in any scenario.
 - **General N+1 audit on the commit show page** — large commits with many
   test cases / instances likely have hot query patterns worth addressing.
 - ~~**Upgrade Octokit 4 → 10.**~~ Done. Drop-in bump — the

--- a/docs/sync-overhaul.md
+++ b/docs/sync-overhaul.md
@@ -1,0 +1,274 @@
+# GitHub sync overhaul
+
+This document captures the plan to replace the current `Branch.api_update_branches`
+sync flow with a topology-driven one. The overhaul lands on its own branch
+(working name: `perf-sync-topology`) and is expected to span multiple
+sessions.
+
+This is the follow-up to Phase 3, which moved sync off the webhook request
+path with `BranchSyncJob` but did **not** reduce the underlying API-call
+fan-out. That part is what this overhaul tackles.
+
+## The problem
+
+`Branch.api_update_branches` does roughly this for every push:
+
+1. `api.branches(repo)` — list current branches (paginated).
+2. For each branch whose head differs from the DB:
+   - `branch.api_update` → `api.commits(sha: branch_name, per_page: 100)`,
+     possibly up to 5 pages (500 commits) if no overlap with the DB is
+     found.
+   - For each commit returned: upsert it, fire
+     `after_create :api_update_test_cases` if new, which makes one
+     `api.content(...)` call per MESA module (currently 4).
+   - Recompute `branch_memberships.position` by reverse-iterating the
+     fetched window and writing positions via `upsert_all`.
+3. Delete branches that no longer exist on GitHub.
+
+The cost scales with **fetched window × modules**, not with **actual new
+commits**. A push of one commit still triggers ~100 commits worth of
+re-positioning and 4 content calls per new commit. A push of 50 new
+commits across 5 modules triggers ~250 content calls.
+
+The deeper issue, behind the API-call count, is that **`position` is not
+a stable ordering** — it gets rewritten on every sync because the algorithm
+recomputes it from whatever window of commits it happens to fetch. That's
+why the algorithm has to fetch a wide window in the first place: it's
+trying to establish enough context to assign positions consistently.
+
+## The goal
+
+**Commit ordering on each branch matches `github.com/MESAHub/mesa/commits/{branch}`.**
+
+That target is concretely:
+
+- **Reachability**: every commit reachable from the branch tip, walking
+  *all* parent edges (not first-parent only). Merge commits and the
+  commits they bring in are both included.
+- **Order**: reverse chronological by `commit_time`.
+
+This matches `git log <branch>` with default options and is the cheapest
+of the plausible sort rules to compute from local state.
+
+## The data model change
+
+One new table:
+
+```ruby
+create_table :commit_relations do |t|
+  t.bigint :parent_id, null: false
+  t.bigint :child_id,  null: false
+  # Optional: parent_index — only nonzero for merge commits; lets you
+  # reconstruct first-parent walks if we ever need them.
+end
+add_index :commit_relations, [:child_id, :parent_id], unique: true
+add_index :commit_relations, :parent_id
+add_foreign_key :commit_relations, :commits, column: :parent_id
+add_foreign_key :commit_relations, :commits, column: :child_id
+```
+
+Why a join table rather than columns on `commits`:
+
+1. Merge commits have ≥ 2 parents (octopus merges can have more).
+2. We need symmetric "parents of X" and "children of X" indexed lookups.
+   "Next commit in the branch" walks toward children.
+3. Per-edge metadata (e.g., parent index for first-parent reconstruction)
+   has a natural home.
+4. Matches the codebase's existing m:n style (`branch_memberships`,
+   `test_case_commits`, `instance_inlists`).
+5. Handles the "we know the SHA but not the metadata yet" case cleanly —
+   we can hold a stub `commits` row and fill it in later without
+   breaking FK semantics.
+
+The `commit_relations` factory at
+[`spec/factories/commit_relations.rb`](../spec/factories/commit_relations.rb)
+already exists, suggesting someone (probably you) had this thought
+previously.
+
+`branch_memberships` stays — it's the cache for "which branches contain
+this commit," and computing that from topology on every page render
+would be expensive. The `position` column on it goes away.
+
+## The new sync flow
+
+For each push webhook:
+
+1. **Identify what's new.** Read the payload's `commits[]` (which
+   includes parent SHAs per commit). If the payload truncates (GitHub
+   caps it at 20 commits per push), call
+   `compare(before_sha, after_sha)` once for the explicit ordered list.
+2. **Insert new edges.** For each new commit:
+   - Upsert the `commits` row.
+   - For each parent SHA: ensure a `commits` row exists (insert a stub
+     if not), then insert into `commit_relations`. Already-present edges
+     are no-ops (the unique index makes this idempotent).
+3. **Move the branch pointer.** `branches.head_id = after_sha`'s commit
+   id.
+4. **Update `branch_memberships`.** Add `(branch, commit)` rows for
+   every commit in the compare set. For merge commits, walk back via
+   `commit_relations` to add memberships for any commits brought in
+   from another branch that aren't already on this branch.
+5. **Test cases.** If a new commit's `modified` / `added` list doesn't
+   touch any `*/test_suite/do1_test_source` path, copy the parent's
+   `TestCaseCommit` set instead of calling `api.content(...)`. This is
+   orthogonal to the topology work but ships in the same phase since it
+   shares the "use the webhook payload" theme.
+
+Typical-push cost in the new flow: **zero API calls** (everything's in
+the payload) or one (`compare`, when the payload truncates). Compared to
+the current "fetch 100+ commits per branch + 4 content calls per new
+commit."
+
+## The new ordering query
+
+The commits page for a branch becomes one recursive CTE:
+
+```sql
+WITH RECURSIVE reachable(id) AS (
+  SELECT head_id FROM branches WHERE name = $1
+  UNION
+  SELECT cr.parent_id
+    FROM commit_relations cr
+    JOIN reachable ON cr.child_id = reachable.id
+)
+SELECT c.*
+  FROM commits c
+  JOIN reachable r ON c.id = r.id
+  ORDER BY c.commit_time DESC
+  LIMIT $2 OFFSET $3;
+```
+
+`UNION` (not `UNION ALL`) dedupes, which short-circuits traversal once
+multiple merge paths converge on a shared ancestor. Postgres has
+supported recursive CTEs since 8.4 (2009); this is standard SQL.
+
+At MESA's scale (low thousands of commits per branch), this query runs
+in single-digit milliseconds. If we ever sync a million-commit repo
+we'd add depth-limiting tricks, but that's not on the horizon.
+
+## Sequencing
+
+Each step is its own commit (or small set of commits) on `perf-sync-topology`.
+
+### Step 1 — Add `commit_relations`
+
+Migration adding the table + indexes + FKs described above. No code
+behavior changes. Drops nothing. Low-risk addition that the rest of the
+work builds on.
+
+### Step 2 — Backfill via paginated `api.commits`
+
+A `BranchBackfillJob` per branch. Paginates `api.commits(sha: branch_name)`
+(the endpoint already returns parent SHAs in every response — the current
+code throws them away). Upserts edges from the parent SHAs into
+`commit_relations`. Idempotent so it can be rerun.
+
+Cost: low hundreds of API calls total across all of MESA's branches.
+Probably 10–30 minutes wall-clock with light throttling. Well under the
+5000 req/hour authenticated limit.
+
+After this lands, the topology is populated and we can verify it makes
+sense against a real branch (does the recursive CTE return the same
+commits in the same order as GitHub.com?) before changing any
+user-visible behavior.
+
+### Step 3 — Rewrite the sync flow
+
+`BranchSyncJob` (added in Phase 3) starts consuming the webhook payload
+directly. New helpers on `Commit` to ingest a `commits[]` array,
+record parent edges, and update branch memberships. Existing
+`api_update_branches` and `Branch#api_update` get retired in this step
+or in step 5, depending on how clean the cut comes out.
+
+Add `compare(before, after)` as the fallback path for truncated
+payloads. Single API call per push instead of N pages.
+
+### Step 4 — Switch ordering to the recursive CTE
+
+Update queries that read `branch_memberships.position`:
+
+- [`app/models/branch.rb`](../app/models/branch.rb) — `nearby_commits`,
+  `nearby_test_case_commits`, `api_reorder_*` (probably all delete-able
+  by the end of this step)
+- [`app/controllers/commits_controller.rb`](../app/controllers/commits_controller.rb)
+  — `index` action's `@memberships = @branch.branch_memberships.where.not(position: nil).order(position: :desc)`
+- Any view that reads `position` directly
+
+Define `Branch#ordered_commits(limit:, offset:)` (or similar) backed by
+the CTE. Have controllers call that.
+
+### Step 5 — Drop the position column
+
+Migration to remove `branch_memberships.position`. Delete the
+renumbering code in `Branch#api_update`. Delete the dead
+`api_update_tree` while we're in there (it's marked as unused in a
+comment).
+
+### Step 6 — Skip `api_update_test_cases` when source files unchanged
+
+For each new commit, check the webhook payload's `modified` and `added`
+lists for any path matching `*/test_suite/do1_test_source`. If none,
+copy the parent commit's `TestCaseCommit` set instead of firing the
+existing 4 module content calls.
+
+This is orthogonal to the topology work — could ship before steps 4–5 if
+we want a quicker partial win.
+
+## Decisions already made
+
+- **Match GitHub.com ordering** (reverse chrono over reachable set), not
+  first-parent or topo-only. Easiest to compute, matches what users see
+  on GitHub.
+- **Join table, not array column.** Better querying, indexing, FK
+  behavior, and matches the codebase pattern.
+- **Clean cutover, not lazy hybrid.** Two code paths (old position-based,
+  new topology-based) for any extended period is more operational cost
+  than the few hundred backfill API calls saves.
+- **Keep `branch_memberships`, drop `position`.** The "which branches
+  contain commit X" question is still expensive to answer from raw
+  topology; the table earns its keep as a cache.
+
+## Open questions for when work begins
+
+- Do we want `parent_index` on `commit_relations` from day one (lets us
+  reconstruct first-parent walks for any future "branch's official
+  history" view), or add it later if/when that view is wanted?
+- Does the backfill job throttle itself, or do we just let it run as
+  fast as the rate limit allows? `faraday-http-cache` is already wired
+  in, so a lot of repeated calls will be 304s, but 304s still count
+  against the limit.
+- Inside step 3, should the new sync code live on `BranchSyncJob`
+  directly, or do we factor out a `Sync::CommitGraph` service object?
+  Lean toward keeping it on the job until we see what shape the code
+  wants to take.
+- Step 6's "copy parent TCCs" — what exactly do we copy? The
+  `TestCaseCommit` rows pointing at the new commit, but with reset
+  per-commit counters (status, submission_count, computer_count). Spec
+  this carefully before implementing.
+
+## Out of scope
+
+- **Solid Queue.** ActiveJob's `:async` adapter is fine for the
+  current load. Adopt Solid Queue if we want job deduplication or
+  durability, but that's a separate decision.
+- **GraphQL API.** The REST `commits` and `compare` endpoints give us
+  everything we need; no reason to add GraphQL complexity.
+- **Real-time updates beyond push events.** PR open/close/merge events
+  can come later if they're worth ingesting at all.
+
+## When this lands
+
+Test suite is expected to grow with the work. The current 78-spec suite
+will need at least:
+
+- Model specs around `commit_relations` insertion via `Commit.ingest_payload`
+  (or whatever the new entry point is called).
+- A request spec asserting webhook push events drive the new flow without
+  hitting `api.commits` at all (the existing webhook spec already proves
+  the job indirection; this proves the inside-the-job behavior).
+- An ordering spec asserting the recursive CTE returns commits in the
+  same order GitHub.com does for a constructed scenario with a merge.
+- A backfill job spec proving idempotence.
+
+When all six steps are green, retiring `branch_memberships.position`
+should be a small migration with confidence backed by the new specs.

--- a/spec/jobs/branch_sync_job_spec.rb
+++ b/spec/jobs/branch_sync_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe BranchSyncJob, type: :job do
+  include ActiveJob::TestHelper
+
+  it 'is queued on the default queue' do
+    expect { described_class.perform_later }
+      .to have_enqueued_job(described_class).on_queue('default')
+  end
+
+  it 'delegates to Branch.api_update_branches when performed' do
+    allow(Branch).to receive(:api_update_branches)
+    described_class.new.perform
+    expect(Branch).to have_received(:api_update_branches).once
+  end
+end

--- a/spec/models/branch_api_update_spec.rb
+++ b/spec/models/branch_api_update_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+# These specs exercise Branch.api_update_branches against the real DB, but
+# stub the outbound GitHub calls. They focus on the deletion path — branches
+# that exist locally but no longer exist on GitHub.
+RSpec.describe Branch, '.api_update_branches', type: :model do
+  # Sawyer::Resource gives both hash-style ([:foo]) and method-style (.foo)
+  # access. This tiny stand-in does the same for our purposes.
+  class FakeApiResource
+    def initialize(data)
+      @data = data.deep_symbolize_keys
+    end
+
+    def [](key)
+      val = @data[key.to_sym]
+      val.is_a?(Hash) ? FakeApiResource.new(val) : val
+    end
+
+    def name = @data[:name]
+    def commit = FakeApiResource.new(@data[:commit])
+    def sha = @data[:sha]
+  end
+
+  let(:head_sha) { 'a' * 40 }
+
+  let(:keep_branch) do
+    branch = create(:branch, name: 'keeper')
+    commit = create(:commit, sha: head_sha, short_sha: head_sha[0, 7])
+    BranchMembership.create!(branch: branch, commit: commit, position: 1)
+    branch.update!(head: commit)
+    branch
+  end
+
+  let(:doomed_branch) do
+    branch = create(:branch, name: 'doomed')
+    commit = create(:commit)
+    BranchMembership.create!(branch: branch, commit: commit, position: 1)
+    branch.update!(head: commit)
+    branch
+  end
+
+  before do
+    keep_branch
+    doomed_branch
+    # Pretend GitHub still has `keeper` (with the same head SHA so the
+    # per-branch api_update is skipped) and that `doomed` has been deleted.
+    allow(Branch).to receive(:api_branches).and_return(
+      [FakeApiResource.new(name: 'keeper', commit: { sha: head_sha })]
+    )
+  end
+
+  it 'deletes branches that no longer exist on GitHub' do
+    expect { Branch.api_update_branches }
+      .to change { Branch.exists?(name: 'doomed') }.from(true).to(false)
+  end
+
+  it 'deletes the memberships of the deleted branch' do
+    doomed_id = doomed_branch.id
+    expect { Branch.api_update_branches }
+      .to change { BranchMembership.where(branch_id: doomed_id).count }
+      .from(1).to(0)
+  end
+
+  it 'leaves the kept branch and its memberships intact' do
+    Branch.api_update_branches
+
+    expect(Branch.find_by(name: 'keeper')).to eq(keep_branch)
+    expect(keep_branch.branch_memberships.count).to eq(1)
+  end
+
+  it 'does not delete commits that lived in the deleted branch' do
+    # Orphaned commits stay; the comment in api_update_branches says they get
+    # cleaned up by a separate weekly task.
+    doomed_commit_sha = doomed_branch.commits.first.sha
+    Branch.api_update_branches
+    expect(Commit.exists?(sha: doomed_commit_sha)).to be true
+  end
+
+  context 'with multiple deletions and shared commits' do
+    let(:shared_commit) { create(:commit, sha: 's' * 40, short_sha: 'sssssss') }
+    let(:second_doomed) do
+      branch = create(:branch, name: 'doomed-2')
+      BranchMembership.create!(branch: branch, commit: shared_commit, position: 1)
+      branch.update!(head: shared_commit)
+      branch
+    end
+
+    before do
+      second_doomed
+      # Also attach shared_commit to the doomed_branch — when both are deleted,
+      # the commit becomes a true orphan, which exercises the
+      # "leave commits alone" guarantee.
+      BranchMembership.create!(branch: doomed_branch, commit: shared_commit,
+                               position: 2)
+    end
+
+    it 'deletes both vanished branches and all their memberships' do
+      Branch.api_update_branches
+
+      expect(Branch.exists?(name: 'doomed')).to be false
+      expect(Branch.exists?(name: 'doomed-2')).to be false
+      expect(BranchMembership.where(branch_id: [doomed_branch.id,
+                                                second_doomed.id]))
+        .to be_empty
+    end
+
+    it 'leaves the shared commit in place even after both owning branches are gone' do
+      Branch.api_update_branches
+      expect(Commit.exists?(sha: shared_commit.sha)).to be true
+    end
+  end
+
+  context 'with a doomed branch that has no head_id' do
+    before do
+      # Simulate a partially-synced branch: rows exist but the head was never
+      # assigned (e.g., an api_update that crashed mid-flow).
+      doomed_branch.update_column(:head_id, nil)
+    end
+
+    it 'still deletes the branch without raising' do
+      expect { Branch.api_update_branches }.not_to raise_error
+      expect(Branch.exists?(name: 'doomed')).to be false
+    end
+  end
+end

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Branch, type: :model do
+  describe '#nearby_test_case_commits' do
+    let(:branch) { create(:branch, name: 'main') }
+    let(:test_case) { create(:test_case, name: 'tc', module: 'star') }
+
+    it 'returns just the seed TCC when the membership has a nil position' do
+      # Regression: memberships from before the position back-fill have
+      # position == nil; (position + 1) and (0...position) raised and broke
+      # the test_case_commits#show page.
+      commit = create(:commit)
+      BranchMembership.create!(branch: branch, commit: commit, position: nil)
+      tcc = TestCaseCommit.create!(commit: commit, test_case: test_case)
+
+      result = branch.nearby_test_case_commits(tcc)
+      expect(result).to eq([tcc])
+    end
+
+    it 'returns just the seed TCC when the commit is not a member of the branch' do
+      commit = create(:commit)
+      tcc = TestCaseCommit.create!(commit: commit, test_case: test_case)
+
+      result = branch.nearby_test_case_commits(tcc)
+      expect(result).to eq([tcc])
+    end
+  end
+end

--- a/spec/models/commit_computer_info_spec.rb
+++ b/spec/models/commit_computer_info_spec.rb
@@ -1,0 +1,171 @@
+require 'rails_helper'
+
+# Locks in the contract Commit#computer_info exposes to the view. The
+# show page renders entry[:computer].user.name, entry[:spec],
+# entry[:frac], entry[:compilation], etc. — any refactor that batches the
+# queries has to keep all of that working.
+RSpec.describe Commit, '#computer_info' do
+  let(:user) { create(:user, name: 'Sam Submitter') }
+  let(:linux_computer) do
+    create(:computer, user: user, name: 'linux-box', platform: 'linux')
+  end
+  let(:mac_computer) do
+    create(:computer, user: user, name: 'mac-box', platform: 'macOS')
+  end
+  let(:commit) { create(:commit) }
+  let(:test_case_a) { create(:test_case, name: 'tc_a', module: 'star') }
+  let(:test_case_b) { create(:test_case, name: 'tc_b', module: 'star') }
+
+  def make_submission(computer:, compiler:, compiler_version:, compiled:,
+                      platform_version: '24.0', sdk_version: nil,
+                      math_backend: nil)
+    Submission.create!(
+      commit: commit, computer: computer,
+      entire: true, empty: false,
+      compiler: compiler, compiler_version: compiler_version,
+      compiled: compiled,
+      platform_version: platform_version,
+      sdk_version: sdk_version,
+      math_backend: math_backend
+    )
+  end
+
+  def make_test_instance(computer:, test_case:, computer_specification:,
+                         submission:)
+    TestInstance.create!(
+      commit: commit, computer: computer, test_case: test_case,
+      submission: submission,
+      compiler: 'gfortran',
+      passed: true,
+      computer_specification: computer_specification,
+      computer_name: computer.name
+    )
+  end
+
+  context 'with no submissions' do
+    it 'returns an empty array' do
+      expect(commit.computer_info).to eq([])
+    end
+  end
+
+  context 'with one submission and one test instance' do
+    before do
+      submission = make_submission(computer: linux_computer, compiler: 'gfortran',
+                                   compiler_version: '13.2.0', compiled: true)
+      # Both test cases get a TestCaseCommit (the denominator is the count
+      # of test cases the commit *should* run, not the number a single
+      # computer has actually run).
+      TestCaseCommit.create!(commit: commit, test_case: test_case_a)
+      TestCaseCommit.create!(commit: commit, test_case: test_case_b)
+      # The spec string must match what Submission#computer_specification
+      # would produce for that submission, since the numerator query is
+      # joined on (computer_id, computer_specification).
+      spec = "linux 24.0 gfortran 13.2.0"
+      make_test_instance(computer: linux_computer, test_case: test_case_a,
+                         computer_specification: spec, submission: submission)
+    end
+
+    it 'returns one entry with the expected shape' do
+      info = commit.computer_info
+      expect(info.size).to eq(1)
+      entry = info.first
+      expect(entry[:computer]).to eq(linux_computer)
+      expect(entry[:spec]).to eq('linux 24.0 gfortran 13.2.0')
+      expect(entry[:numerator]).to eq(1)
+      expect(entry[:denominator]).to eq(2)
+      expect(entry[:frac]).to be_within(0.001).of(0.5)
+      expect(entry[:compilation]).to eq(:success)
+    end
+
+    it 'returns the user via entry[:computer].user without further DB hits' do
+      info = commit.computer_info
+      # The view does `entry[:computer].user.name` — make sure that path
+      # actually has a loaded user association.
+      expect(info.first[:computer].association(:user)).to be_loaded
+    end
+  end
+
+  context 'with multiple specs from the same computer' do
+    before do
+      make_submission(computer: linux_computer, compiler: 'gfortran',
+                      compiler_version: '13.2.0', compiled: true)
+      make_submission(computer: linux_computer, compiler: 'ifort',
+                      compiler_version: '2021.10', compiled: false)
+      test_case_a; test_case_b
+    end
+
+    it 'returns one entry per unique spec' do
+      expect(commit.computer_info.size).to eq(2)
+    end
+
+    it 'reports :mixed for every entry of a computer with both true and false compiled across specs' do
+      # Existing semantics: compilation status is rolled up per computer,
+      # not per spec. If a computer's submissions contain both true and
+      # false compiled values across any of its specs, every spec entry
+      # for that computer reports :mixed.
+      compilations = commit.computer_info.map { |e| e[:compilation] }
+      expect(compilations).to all(eq(:mixed))
+    end
+  end
+
+  context 'with mixed compilation results across submissions of the same spec' do
+    before do
+      make_submission(computer: linux_computer, compiler: 'gfortran',
+                      compiler_version: '13.2.0', compiled: true)
+      make_submission(computer: linux_computer, compiler: 'gfortran',
+                      compiler_version: '13.2.0', compiled: false)
+      test_case_a
+    end
+
+    it 'reports :mixed when the same spec has both true and false compiled values' do
+      expect(commit.computer_info.first[:compilation]).to eq(:mixed)
+    end
+  end
+
+  context 'with nil compiled across all submissions for a spec' do
+    before do
+      make_submission(computer: linux_computer, compiler: 'gfortran',
+                      compiler_version: '13.2.0', compiled: nil)
+      test_case_a
+    end
+
+    it 'reports :unknown' do
+      expect(commit.computer_info.first[:compilation]).to eq(:unknown)
+    end
+  end
+
+  describe 'query count' do
+    # Pre-refactor, computer_info ran roughly four queries per unique spec
+    # (Computer.find, sub.computer.platform, ti.where, submissions.where).
+    # The new implementation batches everything, so query count should be
+    # constant regardless of how many specs there are. This test fails
+    # loudly if anyone reintroduces a per-spec query.
+    it 'does not scale with the number of unique specs' do
+      6.times do |i|
+        make_submission(
+          computer: i.even? ? linux_computer : mac_computer,
+          compiler: 'gfortran', compiler_version: "13.2.#{i}",
+          compiled: i.odd?
+        )
+      end
+      test_case_a
+
+      query_count = 0
+      subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+        next if payload[:name] == 'SCHEMA'
+        next if payload[:sql] =~ /\A(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)/
+        query_count += 1
+      end
+
+      commit.computer_info
+
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+
+      # Reasonable headroom for the fixed set of queries
+      # (submissions+computer+user, ti grouping, test_cases.count, etc.).
+      # The old implementation would be ~25+ here with six specs across
+      # two computers.
+      expect(query_count).to be <= 8
+    end
+  end
+end

--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Commit, type: :model do
+  describe '.test_candidate' do
+    let(:user) { create(:user) }
+    let(:computer) { create(:computer, user: user) }
+
+    context 'when no main branch exists' do
+      it 'does not infinite-recurse and returns nil when nothing matches' do
+        # Regression: previously, with no Branch.main, the unbranched call
+        # would recurse with branch: Branch.main (= nil), re-enter the
+        # else arm, call Branch.main again, and spin forever.
+        expect { Timeout.timeout(2) { Commit.test_candidate(computer: computer) } }
+          .not_to raise_error
+        expect(Commit.test_candidate(computer: computer)).to be_nil
+      end
+
+      it 'still returns a commit from a non-main branch when one is available' do
+        other_branch = create(:branch, name: 'feature-x')
+        commit = create(:commit)
+        BranchMembership.create!(branch: other_branch, commit: commit)
+
+        result = Timeout.timeout(2) { Commit.test_candidate(computer: computer) }
+        expect(result).to eq(commit)
+      end
+    end
+
+    context 'when a main branch exists' do
+      it 'prefers a candidate on main over other branches' do
+        main = create(:branch, name: 'main')
+        other = create(:branch, name: 'feature-y')
+
+        main_commit = create(:commit)
+        other_commit = create(:commit)
+        BranchMembership.create!(branch: main, commit: main_commit)
+        BranchMembership.create!(branch: other, commit: other_commit)
+
+        expect(Commit.test_candidate(computer: computer)).to eq(main_commit)
+      end
+    end
+  end
+end

--- a/spec/models/github_api_wiring_spec.rb
+++ b/spec/models/github_api_wiring_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+# Catches breakage in the Octokit middleware stack wired up at the top of
+# app/models/application_record.rb. Doesn't hit the network — these specs
+# only verify that the constants and the Faraday RackBuilder configuration
+# are intact, which is the kind of thing a major Octokit bump can silently
+# break.
+RSpec.describe 'GitHub API client wiring' do
+  it 'exposes an Octokit::Client through ApplicationRecord.api' do
+    expect(ApplicationRecord.api).to be_an(Octokit::Client)
+  end
+
+  it 'exposes a non-auto-paginating client variant' do
+    expect(ApplicationRecord.api(auto_paginate: false)).to be_an(Octokit::Client)
+  end
+
+  it 'returns the same auto-paginating client on repeated calls' do
+    expect(ApplicationRecord.api).to equal(ApplicationRecord.api)
+  end
+
+  it 'uses MESAHub/mesa as the repo path' do
+    expect(ApplicationRecord.repo_path).to eq('MESAHub/mesa')
+  end
+
+  it 'configures the Octokit middleware with Faraday::HttpCache and Octokit::Response::RaiseError' do
+    handler_classes = Octokit.middleware.handlers.map(&:klass)
+    expect(handler_classes).to include(Faraday::HttpCache)
+    expect(handler_classes).to include(Octokit::Response::RaiseError)
+  end
+
+  it 'still has Octokit::NotFound available for rescue clauses' do
+    expect(defined?(Octokit::NotFound)).to eq('constant')
+    expect(Octokit::NotFound.ancestors).to include(StandardError)
+  end
+
+  it 'Commit.api delegates to the same client (Commit inherits from ApplicationRecord)' do
+    expect(Commit.api).to equal(ApplicationRecord.api)
+    expect(Branch.api).to equal(ApplicationRecord.api)
+  end
+end

--- a/spec/models/test_instance_query_spec.rb
+++ b/spec/models/test_instance_query_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+# Diagnostic spec for the broken test_instances#search feature.
+# Once we identify the failure mode, this stays as a regression spec.
+RSpec.describe TestInstance, '.query', type: :model do
+  it 'parses a single key:value pair' do
+    expect(TestInstance.split_query('passed: true')).to eq('passed' => 'true')
+  end
+
+  it 'parses compound key:value pairs separated by semicolons' do
+    expect(TestInstance.split_query('user: Bill Wolf; passed: true'))
+      .to eq('user' => 'Bill Wolf', 'passed' => 'true')
+  end
+
+  it 'runs a simple passed=true query without raising' do
+    relation, failures = TestInstance.query('passed: true')
+    expect { relation.to_a }.not_to raise_error
+    expect(failures).to be_empty
+  end
+
+  it 'reports failures for unknown keys' do
+    _, failures = TestInstance.query('nonexistent_field: anything')
+    expect(failures).to include('nonexistent_field')
+  end
+
+  it 'runs a compound query without raising' do
+    _, failures = TestInstance.query('passed: true; compiler: gfortran')
+    expect(failures).to be_empty
+  end
+
+  describe 'each documented search option from the help text' do
+    %w[test_case passed computer user platform platform_version
+       rn_RAM re_RAM threads compiler compiler_version runtime].each do |opt|
+      it "accepts #{opt} as a valid search key" do
+        _, failures = TestInstance.query("#{opt}: foo")
+        expect(failures).not_to include(opt),
+          "search option `#{opt}` rejected — likely the column it points " \
+          "to was renamed or removed"
+      end
+    end
+  end
+
+  describe 'empty / whitespace input' do
+    it 'does not raise when query_text is empty' do
+      expect { TestInstance.query('') }.not_to raise_error
+    end
+
+    it 'does not raise when query_text is whitespace only' do
+      expect { TestInstance.query('   ') }.not_to raise_error
+    end
+  end
+
+  describe 'runtime option' do
+    it 'evaluates a runtime range query without raising' do
+      # `runtime` is wired to TestInstance#total_runtime_minutes — confirm
+      # that column actually exists by forcing the query to evaluate.
+      relation, failures = TestInstance.query('runtime: 1-100')
+      expect(failures).to be_empty
+      expect { relation.to_a }.not_to raise_error
+    end
+  end
+
+  describe 'unparseable date / datetime input' do
+    it 'reports date parse failures instead of raising' do
+      expect { TestInstance.query('date: not-a-real-date') }.not_to raise_error
+    end
+
+    it 'reports datetime parse failures instead of raising' do
+      expect { TestInstance.query('datetime: not-a-real-datetime') }
+        .not_to raise_error
+    end
+  end
+end

--- a/spec/requests/github_webhooks_spec.rb
+++ b/spec/requests/github_webhooks_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require 'openssl'
 
 RSpec.describe 'GitHub webhooks', type: :request do
+  include ActiveJob::TestHelper
+
   let(:secret) { 'test-webhook-secret' }
   let(:payload) do
     {
@@ -16,16 +18,31 @@ RSpec.describe 'GitHub webhooks', type: :request do
   before do
     # The controller reads ENV['GITHUB_WEBHOOK_SECRET'] in webhook_secret(payload).
     stub_const('ENV', ENV.to_hash.merge('GITHUB_WEBHOOK_SECRET' => secret))
-    # The push handler fans out to Branch.api_update_branches, which hits the
-    # GitHub API. We're testing controller wiring, not the sync flow.
-    allow(Branch).to receive(:api_update_branches).and_return(true)
   end
 
   def signature_for(body)
     'sha256=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), secret, body)
   end
 
-  it 'accepts a valid push event and triggers the branch sync' do
+  it 'accepts a valid push event and enqueues the branch sync job' do
+    expect {
+      post '/github_webhooks', params: payload,
+                               headers: {
+                                 'Content-Type' => 'application/json',
+                                 'X-GitHub-Event' => 'push',
+                                 'X-Hub-Signature-256' => signature_for(payload)
+                               }
+    }.to have_enqueued_job(BranchSyncJob)
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'does not call Branch.api_update_branches inline during the request' do
+    # The whole point of the job indirection is that the controller returns
+    # before the GitHub sync happens. If someone deletes the job and puts
+    # the inline call back, the webhook will start timing out on big pushes.
+    allow(Branch).to receive(:api_update_branches)
+
     post '/github_webhooks', params: payload,
                              headers: {
                                'Content-Type' => 'application/json',
@@ -33,7 +50,21 @@ RSpec.describe 'GitHub webhooks', type: :request do
                                'X-Hub-Signature-256' => signature_for(payload)
                              }
 
-    expect(response).to have_http_status(:ok)
+    expect(Branch).not_to have_received(:api_update_branches)
+  end
+
+  it 'executes Branch.api_update_branches when the queued job runs' do
+    allow(Branch).to receive(:api_update_branches)
+
+    perform_enqueued_jobs do
+      post '/github_webhooks', params: payload,
+                               headers: {
+                                 'Content-Type' => 'application/json',
+                                 'X-GitHub-Event' => 'push',
+                                 'X-Hub-Signature-256' => signature_for(payload)
+                               }
+    end
+
     expect(Branch).to have_received(:api_update_branches)
   end
 
@@ -44,38 +75,41 @@ RSpec.describe 'GitHub webhooks', type: :request do
   # the sync code path.
   it 'rejects requests with an invalid signature' do
     expect {
-      post '/github_webhooks', params: payload,
-                               headers: {
-                                 'Content-Type' => 'application/json',
-                                 'X-GitHub-Event' => 'push',
-                                 'X-Hub-Signature-256' => 'sha256=' + 'f' * 64
-                               }
-    }.to raise_error(AbstractController::ActionNotFound)
-    expect(Branch).not_to have_received(:api_update_branches)
+      expect {
+        post '/github_webhooks', params: payload,
+                                 headers: {
+                                   'Content-Type' => 'application/json',
+                                   'X-GitHub-Event' => 'push',
+                                   'X-Hub-Signature-256' => 'sha256=' + 'f' * 64
+                                 }
+      }.to raise_error(AbstractController::ActionNotFound)
+    }.not_to have_enqueued_job(BranchSyncJob)
   end
 
   it 'rejects requests with no signature header' do
     expect {
-      post '/github_webhooks', params: payload,
-                               headers: {
-                                 'Content-Type' => 'application/json',
-                                 'X-GitHub-Event' => 'push'
-                               }
-    }.to raise_error(AbstractController::ActionNotFound)
-    expect(Branch).not_to have_received(:api_update_branches)
+      expect {
+        post '/github_webhooks', params: payload,
+                                 headers: {
+                                   'Content-Type' => 'application/json',
+                                   'X-GitHub-Event' => 'push'
+                                 }
+      }.to raise_error(AbstractController::ActionNotFound)
+    }.not_to have_enqueued_job(BranchSyncJob)
   end
 
-  it 'accepts a ping event without triggering branch sync' do
+  it 'accepts a ping event without enqueuing a sync job' do
     ping_payload = { zen: 'Practicality beats purity.', hook_id: 1 }.to_json
 
-    post '/github_webhooks', params: ping_payload,
-                             headers: {
-                               'Content-Type' => 'application/json',
-                               'X-GitHub-Event' => 'ping',
-                               'X-Hub-Signature-256' => signature_for(ping_payload)
-                             }
+    expect {
+      post '/github_webhooks', params: ping_payload,
+                               headers: {
+                                 'Content-Type' => 'application/json',
+                                 'X-GitHub-Event' => 'ping',
+                                 'X-Hub-Signature-256' => signature_for(ping_payload)
+                               }
+    }.not_to have_enqueued_job(BranchSyncJob)
 
     expect(response).to have_http_status(:ok)
-    expect(Branch).not_to have_received(:api_update_branches)
   end
 end

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -95,10 +95,6 @@ RSpec.describe 'Submissions API', type: :request do
     let(:computer) { create(:computer, user: user) }
 
     it 'returns "no untested commits" when there are none' do
-      # Bypass Commit.test_candidate — it has a separate recursion bug when
-      # no Branch.main exists, which is a Phase 3 cleanup target.
-      allow(Commit).to receive(:test_candidate).and_return(nil)
-
       get '/submissions/request_commit.json', params: {
         submitter: { email: user.email, password: 'pw-12345678',
                      computer: computer.name },

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -33,6 +33,26 @@ RSpec.describe 'Submissions API', type: :request do
       expect(Submission.last.empty).to be true
     end
 
+    it 'renders successfully when the commit has no branch memberships yet' do
+      # Regression: _commit.json.jbuilder used to call commit_url with
+      # commit.branches[0], which raised on commits not yet attached to a
+      # branch — exactly the state of a freshly-ingested commit when the
+      # submissions API runs.
+      orphan_commit = create(:commit)
+
+      post '/submissions/create.json',
+           params: {
+             submitter: valid_submitter,
+             commit: valid_commit.merge(sha: orphan_commit.sha)
+           },
+           as: :json
+
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)
+      expect(body['commit']['sha']).to eq(orphan_commit.sha)
+      expect(body['commit']).not_to have_key('url')
+    end
+
     it 'rejects submissions with an invalid password' do
       post '/submissions/create.json',
            params: {

--- a/spec/support/github_api_stubs.rb
+++ b/spec/support/github_api_stubs.rb
@@ -1,0 +1,15 @@
+# Keep the test suite from hitting GitHub's API.
+#
+# Commit has `after_create :api_update_test_cases`, which fans out to
+# `Commit.api.content(...)` once per MESA module. Every spec that creates a
+# Commit (directly or via a factory) would otherwise burn API calls — and on
+# CI, where there's no GIT_TOKEN, the runner blows through GitHub's 60/hour
+# anonymous limit within the first dozen tests.
+#
+# Stub by default; specs that actually want to exercise the callback can
+# `allow_any_instance_of(Commit).to receive(:api_update_test_cases).and_call_original`.
+RSpec.configure do |config|
+  config.before(:each) do
+    allow_any_instance_of(Commit).to receive(:api_update_test_cases)
+  end
+end


### PR DESCRIPTION
## Summary

Phase 3 of the [modernization roadmap](docs/roadmap.md): performance and bug fixes. 15 commits, suite grew from 24 → 78 specs (zero failures).

## What's in here

**Roadmap items (4):**
- Moved `GithubWebhooksController#github_push` off the request path — now enqueues `BranchSyncJob.perform_later`. Default `:async` adapter; durable queue is a separate decision.
- Locked in the branch-deletion code path with 7 regression specs + a transaction wrapper. The "cascading delete errors" symptom didn't reproduce in any scenario — commit `4fe9fe7` (Mar 2025) had already replaced the old `branch.destroy` loop.
- Eliminated the N+1 in `Commit#computer_info` (was ~4 queries per unique computer/spec tuple — a 20-spec commit ran ~80 queries) plus memoized `compile_stati` so the three back-to-back compilation methods in `commits#show` hit the DB once instead of three times. Query-count regression gate included.
- Octokit 4.25.1 → 10.0.0. Drop-in bump; the middleware-contract concern in the roadmap turned out to be unfounded. New wiring smoke spec.

**Queued bugs (4):**
- `Commit.test_candidate` no longer infinite-recurses when `Branch.main` is nil. Drive-by: removed three stale `puts`, one referencing an undefined `Submissions` constant that crashed the fallback path.
- `_commit.json.jbuilder` no longer raises when a commit has no branch memberships yet (which is exactly the state of a freshly-ingested commit hitting the submissions API).
- `Branch#nearby_test_case_commits` no longer raises on memberships with `nil` position.
- Four bugs in `TestInstance.query` that broke `/test_instances/search`: empty input crash, `runtime` searched a non-existent column, malformed date/datetime crashed instead of going on the failures list.

**Follow-up doc:**
- [`docs/sync-overhaul.md`](docs/sync-overhaul.md) — plan for Phase 3.5, the topology-driven sync rewrite. Phase 3 took the sync off the request path but did **not** reduce the API-call fan-out; that's what 3.5 tackles, on its own branch (`perf-sync-topology`).

## Test plan

- [x] Full RSpec suite green (78 examples, 0 failures)
- [x] `rails runner` smoke test confirming Octokit 10.0.0 boots and the middleware stack is intact
- [ ] Spot-check a webhook delivery in dev after merge to confirm `BranchSyncJob` enqueues
- [ ] Watch first few production webhooks after deploy for `BranchSyncJob` perform timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)