### PR TITLE
Fix test-case population cascade in backfill ordering

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -106,12 +106,24 @@ class Commit < ApplicationRecord
   # map isn't provided (backfill / reconcile path), populate falls back
   # to copy-from-parent as the optimistic default — correct for MESA's
   # workflow where source files rarely change.
+  #
+  # Iteration order matters: commits must be processed in commit_time
+  # ASC order so a commit's parent is populated before the commit
+  # itself. Otherwise a chain of newly-ingested commits with no TCCs
+  # cascades — each commit's copy-from-parent fails (parent not
+  # populated yet) and falls back to an api.content call. Under
+  # backfill that's 300 API calls + per-commit DB writes per page of
+  # 100, vs. ~3 API calls + 99 fast copies with the right order. We
+  # load into memory rather than use find_each so the order isn't
+  # overridden by find_each's primary-key batching.
   def self.populate_payload_test_cases(commit_hashes, sha_to_id,
                                        file_changes_by_sha: nil)
     ids = commit_hashes.map { |gh| sha_to_id[gh[:sha]] }.compact
     return if ids.empty?
 
-    Commit.where(id: ids, test_case_count: 0).find_each do |commit|
+    Commit.where(id: ids, test_case_count: 0)
+          .order(commit_time: :asc)
+          .each do |commit|
       sources_touched = file_changes_by_sha&.dig(commit.sha)&.then do |paths|
         paths.any? { |p| p.match?(TEST_SOURCE_PATTERN) }
       end

--- a/lib/tasks/populate_test_cases.rake
+++ b/lib/tasks/populate_test_cases.rake
@@ -3,13 +3,20 @@ namespace :test_cases do
        "Copies from parent commit when possible, falls back to fetching " \
        "do1_test_source from GitHub. Idempotent."
   task populate: :environment do
-    bad = Commit.where(test_case_count: 0)
+    # Order by commit_time ASC so each commit's parent is processed
+    # before the commit itself — copy-from-parent then works for the
+    # whole chain after at most one api fetch for the chain's root.
+    # Without this, find_each's primary-key ordering processes
+    # newer commits first (for backfill-ingested batches, where newer
+    # commits have lower IDs) and every commit's copy-from-parent
+    # fails, cascading into api fetches.
+    bad = Commit.where(test_case_count: 0).order(commit_time: :asc)
     total = bad.count
     puts "Found #{total} commits without test cases. Populating..."
 
     copied, fetched, skipped = 0, 0, 0
 
-    bad.find_each.with_index(1) do |commit, i|
+    bad.each.with_index(1) do |commit, i|
       result = Commit.populate_test_cases_for(commit)
       commit.reload
       case result

--- a/spec/models/commit_test_case_population_spec.rb
+++ b/spec/models/commit_test_case_population_spec.rb
@@ -197,6 +197,59 @@ RSpec.describe Commit, 'test case population' do
       expect_any_instance_of(Commit).not_to receive(:api_update_test_cases)
       Commit.populate_payload_test_cases(payload, sha_to_id)
     end
+
+    it 'processes a chain of new commits in commit_time ASC so each ' \
+       'child can copy from its just-populated parent (single api fetch)' do
+      # Regression: previously this iterated via find_each (id ASC),
+      # which under backfill processes newest-first. Each commit's
+      # parent hadn't been populated yet, so every commit cascaded
+      # into api_update_test_cases — 3 API calls per commit instead
+      # of 1 for the whole chain.
+      tc = create(:test_case, name: 'evolve_zams', module: 'star')
+      seed = create(:commit, sha: sha40('seed'),
+                             short_sha: sha40('seed')[0, 7])
+      TestCaseCommit.create!(commit: seed, test_case: tc)
+      seed.save  # update_scalars → test_case_count = 1
+
+      # Build a chain: seed (has TCC) ← oldest ← middle ← newest
+      # All three children have higher IDs (more recently inserted)
+      # than their parents, but earlier commit_time means they should
+      # process first.
+      base_time = Time.zone.parse('2026-01-01T00:00:00Z')
+      oldest_sha = sha40('oldest')
+      middle_sha = sha40('middle')
+      newest_sha = sha40('newest')
+
+      # Insert in newest-first order to mimic backfill — newest gets
+      # lowest new ID. Then populate sees newest first if we don't
+      # fix the ordering.
+      payload = [
+        gh_commit(sha: newest_sha, parent_shas: [middle_sha]),
+        gh_commit(sha: middle_sha, parent_shas: [oldest_sha]),
+        gh_commit(sha: oldest_sha, parent_shas: [seed.sha])
+      ]
+      # Override commit_time so each is one hour apart, newest last
+      payload[0][:commit][:author][:date] = base_time + 3.hours
+      payload[1][:commit][:author][:date] = base_time + 2.hours
+      payload[2][:commit][:author][:date] = base_time + 1.hour
+
+      sha_to_id = Commit.ingest_payload_commits(payload)
+      Commit.ingest_payload_edges(payload, sha_to_id)
+
+      # Sanity check: newest has lower ID than oldest (the cascade trap)
+      expect(sha_to_id[newest_sha]).to be < sha_to_id[oldest_sha]
+
+      # No api fetch should fire — every commit in the chain copies
+      # from its parent (oldest copies from seed; middle copies from
+      # oldest; newest copies from middle).
+      expect_any_instance_of(Commit).not_to receive(:api_update_test_cases)
+
+      Commit.populate_payload_test_cases(payload, sha_to_id)
+
+      [oldest_sha, middle_sha, newest_sha].each do |sha|
+        expect(Commit.find_by(sha: sha).test_case_count).to eq(1)
+      end
+    end
   end
 
   describe Commit::TEST_SOURCE_PATTERN do


### PR DESCRIPTION
## Summary

Hotfix for the post-deploy `topology:backfill` run hanging on production. Symptom: 10+ minutes of `TestCaseCommit.create` log spam with the task never completing.

## Root cause

`Commit.populate_payload_test_cases` iterated commits via `find_each`, which orders by primary key ASC. Under `BranchBackfillJob` (which walks `api.commits` newest-first), the newest commit gets the lowest new ID and is processed first. Its parent has a higher new ID and hasn't been populated yet, so `copy_test_cases_from_parent` returns false and falls back to `api_update_test_cases` (3 API calls + per-test-case `TestCaseCommit.create`). Then the parent gets processed, same problem. Cascade.

For a page of 100 fresh commits with no existing TCCs, that's ~300 API calls + 100 commits' worth of writes instead of ~3 API calls + 99 fast in-DB copies.

## Fix

Order by `commit_time ASC` so each commit's parent is processed before the commit itself. Same fix applied to the `test_cases:populate` rake task, which had the same problem for its broader scan.

## Test plan

- [x] Full RSpec suite passes (159/159; added one regression spec)
- [x] Regression spec constructs a chain of three new commits inserted newest-first (so IDs reverse chronological order) and asserts `populate_payload_test_cases` never calls `api_update_test_cases` — every commit copies from its just-populated parent
- [ ] After deploy: re-run `bundle exec rake topology:backfill` on prod — should complete in well under a minute now
- [ ] If commit_relations is already mostly populated from the partial earlier run, the backfill short-circuit will skip most pages quickly