### PR TITLE
Fix mobile overflow on commits index, computer cards, and history tab

### DIFF
--- a/app/views/commits/_subway_map.html.haml
+++ b/app/views/commits/_subway_map.html.haml
@@ -52,7 +52,12 @@
 - min_shift = -(track_w - window_w)
 - initial_shift = (@map_initial_view == :oldest) ? min_shift : max_shift
 
-.rounded-lg.border.border-border.bg-bg-elev.p-4{ style: "box-shadow: var(--shadow-card-sm);" }
+-# The map's pan controller relies on fixed pixel widths
+-# (window_w grows with visible_count). At 13 visible commits
+-# the natural width is ~908px, which won't fit below the lg
+-# breakpoint. Hide it on narrow viewports — the table below
+-# carries the same data with more detail.
+.hidden.lg:block.rounded-lg.border.border-border.bg-bg-elev.p-4{ style: "box-shadow: var(--shadow-card-sm);" }
   .flex.items-center.justify-between.font-semibold.uppercase.tracking-wide.text-fg-subtle.mb-3{ class: "text-[11px]" }
     %span Visible commits
     %span.normal-case.font-normal.text-fg-subtle.tabular-nums

--- a/app/views/commits/_tab_computers.html.haml
+++ b/app/views/commits/_tab_computers.html.haml
@@ -8,9 +8,13 @@
 -# Column count auto-fills from viewport width so words like
 -# "CHECKSUM" never bleed past a card edge. The 5-mini-stat grid
 -# inside each card needs ~5 × 78px = 390px just for the labels +
--# numbers, plus 28px of card padding. 420px is the minimum that
--# fits without text overflow; below that we drop to one column.
-.grid.gap-3{ style: "grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));" }
+-# numbers, plus 28px of card padding. 420px is the comfortable
+-# minimum on desktop; below that we drop to a single column that
+-# can be narrower than 420px without overflowing the viewport.
+-# The `min(420px, 100%)` trick lets the track shrink past 420px
+-# on narrow viewports while still treating 420px as the target
+-# wrap point on wider ones.
+.grid.gap-3{ style: "grid-template-columns: repeat(auto-fill, minmax(min(420px, 100%), 1fr));" }
   - @per_computer.each do |row|
     - computer = row[:computer]
     - accent = computer_state_color(row[:state])
@@ -44,7 +48,11 @@
           = sdk_label
 
       - if row[:built]
-        .grid.grid-cols-5.gap-2
+        -# 5-stat grid. Below sm, a single full-width card on a 375px
+        -# viewport leaves ~50px per column, which clips "CHECKSUM" on
+        -# its label row. Switch to a 3+2 layout there; from sm up,
+        -# cards are wide enough (>=420px) for the full row.
+        .grid.grid-cols-3.gap-2{ class: "sm:grid-cols-5" }
           - %i[pass fail pending fpe checksum].each do |key|
             .rounded-md.bg-bg-subtle.px-2.py-1.text-center
               %div.text-fg-subtle.uppercase.tracking-wide{ class: "text-[10px]" }= key.to_s.upcase

--- a/app/views/test_cases/_tab_history.html.haml
+++ b/app/views/test_cases/_tab_history.html.haml
@@ -64,19 +64,24 @@
                     data: { instance_filter_target: "search",
                             action: "input->instance-filter#search" } }
 
-          .inline-flex.rounded-md.border.border-border.bg-bg-elev.p-0.5.gap-0.5
-            - status_specs.each do |id, label, count, dot|
-              - on = (id == "all")
-              %button{ type: "button",
-                       "aria-pressed": on.to_s,
-                       class: "inline-flex items-center gap-1.5 rounded-sm px-2 py-1 text-xs font-medium cursor-pointer transition-colors #{on ? 'bg-brand-soft text-brand-soft-text' : 'text-fg-muted hover:bg-bg-muted'}",
-                       data: { instance_filter_target: "statusChip",
-                               status: id,
-                               action: "click->instance-filter#selectStatus" } }
-                - if dot
-                  %span{ class: "inline-block h-1.5 w-1.5 rounded-full #{dot}" }
-                %span= label
-                %span.font-mono.tabular-nums.text-fg-subtle{ class: "text-[10px]" }= count
+          -# Status segment. Six buttons in a single row don't fit a
+          -# 375px viewport (~487px natural width), so the segment
+          -# wraps in a horizontally-scrollable container that hugs
+          -# its own content on wider screens.
+          .max-w-full.overflow-x-auto
+            .inline-flex.rounded-md.border.border-border.bg-bg-elev.p-0.5.gap-0.5{ class: "flex-nowrap" }
+              - status_specs.each do |id, label, count, dot|
+                - on = (id == "all")
+                %button{ type: "button",
+                         "aria-pressed": on.to_s,
+                         class: "inline-flex items-center gap-1.5 rounded-sm px-2 py-1 text-xs font-medium cursor-pointer transition-colors whitespace-nowrap #{on ? 'bg-brand-soft text-brand-soft-text' : 'text-fg-muted hover:bg-bg-muted'}",
+                         data: { instance_filter_target: "statusChip",
+                                 status: id,
+                                 action: "click->instance-filter#selectStatus" } }
+                  - if dot
+                    %span{ class: "inline-block h-1.5 w-1.5 rounded-full #{dot}" }
+                  %span= label
+                  %span.font-mono.tabular-nums.text-fg-subtle{ class: "text-[10px]" }= count
 
         -# Matrix body.
         %div{ style: "overflow-x: auto;" }


### PR DESCRIPTION
## Summary

Audited every main view at a 375px mobile viewport, found three real overflow sources, and corrected them. Test suite stays green (271 specs).

- **commits#index subway map**: the pan controller uses fixed pixel widths (~908px at 13 visible commits) that can't fit below the `lg` breakpoint. Hidden on narrow viewports — the table below carries the same data with more detail.
- **commits#show?tab=computers cards**: `minmax(420px, 1fr)` forced columns to be ≥420px, so each card leaked past a 375px viewport. Switched to `minmax(min(420px, 100%), 1fr)` so the track shrinks past 420px when there isn't room while keeping 420px as the wrap target on wider screens.
- **The 5-stat mini-grid inside each computer card**: only ~50px per column on mobile, which clipped the "CHECKSUM" label past the cell. Dropped to a 3+2 layout under `sm`; full 5-col row from `sm` up where cards are at least 420px.
- **test_cases#show?tab=history status segment**: 6-button single-row inline-flex (~487px natural) had no scroll fallback. Wrapped in `overflow-x-auto max-w-full` so the segment scrolls horizontally within its own bar without pushing the page.

## Reality checks already done

- `/users/1`, `/all_computers`, `?tab=submissions` have wide tables (720–1000px) but they're properly contained by `overflow-x: auto` wrappers — `documentElement.scrollWidth` reports a high value, but `window.scrollX` won't actually change. No fix needed.
- Tailwind rebuilt locally; `tailwindcss:build` is already wired into `assets:precompile` so Railway picks the new utilities up at deploy.

## Test plan

- [ ] Pull, run `bundle exec rspec` — should be 271 examples, 0 failures.
- [ ] Open `/main/commits` at a mobile viewport (375px). Subway map should be hidden; table fits without a horizontal scroll.
- [ ] Open a commit with many computers (e.g. `/main/commits/7a6b1c5?tab=computers`). Cards stack one per row, the PASS/FAIL/PENDING row sits above an FPE/CHECKSUM row, nothing clips.
- [ ] Open `/main/test_cases/star/1.3M_ms_high_Z`. The "All / Failing / Mixed / …" segment scrolls horizontally within its own bar; the page itself does not.
- [ ] Spot-check at `lg` (≥1024px): subway map reappears, computer cards regain the 5-stat row, status segment fits in one row.