### PR TITLE
Store commit_time from committer date so head sits at the top of every list

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -303,16 +303,27 @@ class Commit < ApplicationRecord
   # replaces. Deleted in Step 5 along with the position column.
 
   def self.hash_from_github(github_hash)
-    # convert hash from a github api_request representing a commit to 
-    # a hash ready to be inserted into the database
-    # +github_hash+ a hash for one commit resulting from a github webhook
-    # push payload
+    # Convert a GitHub API commit hash into the columns we store on
+    # `commits`. Driven by api.compare / api.commits (BranchSyncJob,
+    # BranchBackfillJob); the GitHub push-webhook payload's commits[]
+    # array isn't passed here directly — BranchSyncJob calls
+    # api.compare(before, after) instead, which returns the same shape.
+    #
+    # `commit_time` reads the *committer* date, not the author date.
+    # GitHub orders /commits/<branch> by committer date, and the head
+    # of a branch is always the most-recently-committed commit. For
+    # commits applied via Rebase-and-merge or Squash-and-merge, the
+    # author date is preserved (whenever the patch was originally
+    # written) but the committer date is the moment the commit landed
+    # on the branch — that's what makes the head sit at the top of
+    # GitHub's view and is what we want every commit-list view here
+    # to agree on.
     {
       sha: github_hash[:sha],
       short_sha: github_hash[:sha][(0...7)],
       author: github_hash[:commit][:author][:name],
       author_email: github_hash[:commit][:author][:email],
-      commit_time: github_hash[:commit][:author][:date],
+      commit_time: github_hash[:commit][:committer][:date],
       message: github_hash[:commit][:message],
       github_url: github_hash[:html_url]
     }

--- a/lib/tasks/backfill_commit_time.rake
+++ b/lib/tasks/backfill_commit_time.rake
@@ -1,0 +1,60 @@
+namespace :commits do
+  desc "Backfill commits.commit_time with the committer date for " \
+       "commits on every branch within the last N days (default 90). " \
+       "Historical data stored the author date here, which disagrees " \
+       "with the committer date for any commit applied via " \
+       "rebase-and-merge, squash-and-merge, or amend — and that's the " \
+       "ordering that puts the branch head at the top of every list. " \
+       "Idempotent: only writes rows whose stored value actually differs."
+  task :backfill_commit_time, [:days] => :environment do |_, args|
+    days_back = (args[:days] || 90).to_i
+    since_iso = days_back.days.ago.utc.iso8601
+
+    branches = Branch.order(:name)
+    puts "Backfilling commit_time from committer date for " \
+         "#{branches.count} branches (since #{since_iso})..."
+
+    total_checked = 0
+    total_updated = 0
+
+    branches.find_each.with_index(1) do |branch, i|
+      gh_commits = Commit.api_commits(sha: branch.name, since: since_iso)
+      if gh_commits.nil?
+        puts "  [#{i}] #{branch.name}: branch missing on GitHub, skipping"
+        next
+      end
+
+      # Build sha -> committer_date map. Sawyer::Resource responds to
+      # `[:foo]` lookup the same way as a plain Hash, so this works for
+      # both real API responses and stubbed test fixtures.
+      gh_dates = gh_commits.each_with_object({}) do |gh, map|
+        date = gh[:commit][:committer][:date]
+        # Octokit hands us strings here; Postgres-backed Time
+        # comparisons want a Time.
+        map[gh[:sha]] = date.is_a?(String) ? Time.zone.parse(date) : date
+      end
+
+      checked = gh_dates.size
+      updated = 0
+
+      Commit.where(sha: gh_dates.keys)
+            .find_each do |commit|
+        new_time = gh_dates[commit.sha]
+        next if new_time.nil?
+        # Database stores microsecond precision; compare with tolerance
+        # so identical-but-different-precision values don't churn.
+        next if commit.commit_time && (commit.commit_time - new_time).abs < 1.0
+
+        commit.update_columns(commit_time: new_time)
+        updated += 1
+      end
+
+      total_checked += checked
+      total_updated += updated
+      puts "  [#{i}] #{branch.name}: checked #{checked}, updated #{updated}"
+    end
+
+    puts ""
+    puts "Done. checked=#{total_checked} updated=#{total_updated}"
+  end
+end

--- a/spec/jobs/branch_backfill_job_spec.rb
+++ b/spec/jobs/branch_backfill_job_spec.rb
@@ -8,11 +8,12 @@ RSpec.describe BranchBackfillJob, type: :job do
   # `[:foo]` lookup identically. Need the full nested shape because
   # ingest_payload_commits passes it through hash_from_github.
   def fake_commit(sha:, parent_shas: [])
+    time = Time.zone.parse('2026-01-01T12:00:00Z')
     {
       sha: sha,
       commit: {
-        author: { name: 'Bot', email: 'bot@example.com',
-                  date: Time.zone.parse('2026-01-01T12:00:00Z') },
+        author:    { name: 'Bot', email: 'bot@example.com', date: time },
+        committer: { name: 'Bot', email: 'bot@example.com', date: time },
         message: "msg #{sha[0, 7]}"
       },
       html_url: "https://github.com/MESAHub/mesa/commit/#{sha}",

--- a/spec/jobs/branch_sync_job_spec.rb
+++ b/spec/jobs/branch_sync_job_spec.rb
@@ -19,11 +19,12 @@ RSpec.describe BranchSyncJob, type: :job do
 
   # Shape commit hashes the way Octokit returns them from api.compare.
   def gh_commit(sha:, parent_shas: [])
+    time = Time.zone.parse('2026-01-01T12:00:00Z')
     {
       sha: sha,
       commit: {
-        author: { name: 'Bot', email: 'bot@example.com',
-                  date: Time.zone.parse('2026-01-01T12:00:00Z') },
+        author:    { name: 'Bot', email: 'bot@example.com', date: time },
+        committer: { name: 'Bot', email: 'bot@example.com', date: time },
         message: 'msg'
       },
       html_url: "https://github.com/MESAHub/mesa/commit/#{sha}",

--- a/spec/models/commit_ingest_spec.rb
+++ b/spec/models/commit_ingest_spec.rb
@@ -10,11 +10,14 @@ RSpec.describe Commit, 'payload ingestion' do
   # Sawyer::Resource supports `[:foo]` lookup identically.
   def gh_commit(sha:, parent_shas: [], author: 'Test Author',
                 email: 'author@example.com', message: 'msg',
-                date: Time.zone.parse('2026-01-01T12:00:00Z'))
+                date: Time.zone.parse('2026-01-01T12:00:00Z'),
+                committer_date: nil)
     {
       sha: sha,
       commit: {
-        author: { name: author, email: email, date: date },
+        author:    { name: author, email: email, date: date },
+        committer: { name: author, email: email,
+                     date: committer_date || date },
         message: message
       },
       html_url: "https://github.com/MESAHub/mesa/commit/#{sha}",
@@ -87,6 +90,26 @@ RSpec.describe Commit, 'payload ingestion' do
       # api.content() calls per commit per module.
       expect_any_instance_of(Commit).not_to receive(:api_update_test_cases)
       Commit.ingest_payload_commits([gh_commit(sha: sha40('dddd4'))])
+    end
+
+    it 'stores commit_time from the committer date, not the author date' do
+      # Rebase-and-merge / Squash-and-merge / amend rewrite a commit
+      # with a new committer date but preserve the original author
+      # date. GitHub orders /commits/<branch> by committer date and
+      # treats the head as the most-recently-committed commit; all
+      # our views sort by commit_time, so commit_time must read the
+      # committer date or the head won't sit at the top of every list.
+      author_date    = Time.zone.parse('2026-03-15T10:00:00Z')
+      committer_date = Time.zone.parse('2026-03-20T08:00:00Z')
+      payload = [gh_commit(sha: sha40('rebase1'),
+                           date: author_date,
+                           committer_date: committer_date)]
+
+      Commit.ingest_payload_commits(payload)
+
+      row = Commit.find_by(sha: sha40('rebase1'))
+      expect(row.commit_time).to be_within(1.second).of(committer_date)
+      expect(row.commit_time).not_to be_within(1.second).of(author_date)
     end
   end
 

--- a/spec/models/commit_test_case_population_spec.rb
+++ b/spec/models/commit_test_case_population_spec.rb
@@ -124,11 +124,12 @@ RSpec.describe Commit, 'test case population' do
 
   describe '.populate_payload_test_cases' do
     def gh_commit(sha:, parent_shas: [])
+      time = Time.zone.parse('2026-01-01T12:00:00Z')
       {
         sha: sha,
         commit: {
-          author: { name: 'Bot', email: 'bot@example.com',
-                    date: Time.zone.parse('2026-01-01T12:00:00Z') },
+          author:    { name: 'Bot', email: 'bot@example.com', date: time },
+          committer: { name: 'Bot', email: 'bot@example.com', date: time },
           message: "msg #{sha[0, 7]}"
         },
         html_url: "https://github.com/MESAHub/mesa/commit/#{sha}",
@@ -228,10 +229,12 @@ RSpec.describe Commit, 'test case population' do
         gh_commit(sha: middle_sha, parent_shas: [oldest_sha]),
         gh_commit(sha: oldest_sha, parent_shas: [seed.sha])
       ]
-      # Override commit_time so each is one hour apart, newest last
-      payload[0][:commit][:author][:date] = base_time + 3.hours
-      payload[1][:commit][:author][:date] = base_time + 2.hours
-      payload[2][:commit][:author][:date] = base_time + 1.hour
+      # Override commit_time so each is one hour apart, newest last.
+      # hash_from_github reads the committer date (matches GitHub's
+      # /commits ordering); the author date is informational here.
+      payload[0][:commit][:committer][:date] = base_time + 3.hours
+      payload[1][:commit][:committer][:date] = base_time + 2.hours
+      payload[2][:commit][:committer][:date] = base_time + 1.hour
 
       sha_to_id = Commit.ingest_payload_commits(payload)
       Commit.ingest_payload_edges(payload, sha_to_id)


### PR DESCRIPTION
## Summary

`commits.commit_time` was stored from the GitHub commit's *author* date, but GitHub orders `/commits/<branch>` by *committer* date and treats the branch head as the most-recently-committed commit. For commits applied via Rebase-and-merge, Squash-and-merge, or amend, the author date is preserved (whenever the patch was originally written) while the committer date is updated to the moment the commit landed on the branch — so we were sorting by the wrong clock.

The visible symptom: opening `/` correctly resolves to the GitHub head (via the `branches.head_id` FK), but the subway map and commits index showed *other* commits visually newer than that head, because their author dates were later than the head's author date. Two views, two answers, both internally consistent and both with the wrong clock under them.

## What's in this PR

- **`app/models/commit.rb`**: `hash_from_github` now reads `commit.committer.date`. Comment explains the head-at-top invariant.
- **`lib/tasks/backfill_commit_time.rake`**: `rake commits:backfill_commit_time[days]` (default 90). Walks every branch via `api.commits(sha: branch.name, since: …)`, builds a `sha → committer_date` map, and updates only rows whose stored `commit_time` actually differs (1-second tolerance to avoid microsecond churn). One paginated request per branch; idempotent.
- **Specs**: new explicit test that feeds a payload with distinct author and committer dates and pins `commit_time` to the committer one. Updated the four fixture helpers (`gh_commit` / `fake_commit` in `commit_ingest_spec`, `commit_test_case_population_spec`, `branch_sync_job_spec`, `branch_backfill_job_spec`) to emit both `author` and `committer` blocks; defaulted committer to the same date as author so existing assertions stay green. Fixed one test that overrode `[:author][:date]` directly to instead override `[:committer][:date]` so its commit_time differentiation still works.

## Test plan

- [ ] Pull, run `bundle exec rspec` — should be 272 examples (one new), 0 failures.
- [ ] Deploy this PR.
- [ ] On Railway: `railway run bundle exec rake commits:backfill_commit_time`. Confirms per-branch `checked=N updated=M` lines; main should report at least one update for the recent rebase-and-merge commits.
- [ ] Reload `/`. Page title's SHA should match the leftmost station on the subway map and the top row of `/main/commits`. Compare against `https://github.com/MESAHub/mesa/commits/main` — orderings should agree.
- [ ] (Optional) Re-run the rake task; second invocation should print `updated=0` everywhere — the operation is idempotent.

## Notes

- Cap defaults to 90 days because that's where the visually-affected commits live (recent PR merges). Older history is mostly non-rebased, so author == committer and nothing changes. Wider window? `rake commits:backfill_commit_time[180]`.
- Future webhook pushes will store the correct value on first ingest via the code change; the backfill is only for catching up existing rows.