### PR TITLE
Repair test_instances#search after Version-model removal

### DIFF
--- a/app/controllers/test_instances_controller.rb
+++ b/app/controllers/test_instances_controller.rb
@@ -2,11 +2,8 @@ class TestInstancesController < ApplicationController
   layout "modern", only: [:search]
 
   # Cross-cuts every test run on every computer for every commit
-  # using a single key-value query language. The query backend
-  # (`TestInstance.query` on the model) is partially rotted since
-  # the SVN → git transition — see the inline warning on the
-  # search view + the Phase 4 follow-up note in
-  # docs/frontend-modernization.md.
+  # using a single key-value query language. See
+  # `TestInstance.query` for the backend.
   #
   # The JSON variant of this action is what the historic API
   # consumers hit; it requires authentication via the same

--- a/app/models/test_instance.rb
+++ b/app/models/test_instance.rb
@@ -402,9 +402,6 @@ class TestInstance < ApplicationRecord
     # building up the search query from many pre-defined searchable options.
     options = [
       SearchOption.new('test_case', TestCase, :name),
-      # SearchOption.new('version', TestInstance, :mesa_version, true) do |number|
-        # number.to_i 
-      # end,
       SearchOption.new('commit', Commit, :short_sha) do |sha|
         sha[(0..7)]
       end,
@@ -426,10 +423,18 @@ class TestInstance < ApplicationRecord
       SearchOption.new('re_RAM', self, :mem_re, true) do |mem_GB|
         mem_GB.to_f * (1024**2)
       end,
-      # `total_runtime_seconds` is the column; users enter minutes (or
-      # natural phrasings like "1 hr 30 min") and parse_runtime converts
-      # to seconds. There is no total_runtime_minutes column — relying on
-      # the like-named instance method would break inside a where clause.
+      # Runtime SearchOptions all share parse_runtime — accepts integer
+      # seconds or natural phrasings like "1 hr 30 min". The columns are
+      # `runtime_seconds` (rn step), `re_time` (re step), and
+      # `total_runtime_seconds` (whole test). There is no
+      # total_runtime_minutes column — relying on the like-named instance
+      # method would break inside a where clause.
+      SearchOption.new('rn_runtime', self, :runtime_seconds, true) do |runtime_str|
+        TestInstance.parse_runtime(runtime_str)
+      end,
+      SearchOption.new('re_runtime', self, :re_time, true) do |runtime_str|
+        TestInstance.parse_runtime(runtime_str)
+      end,
       SearchOption.new('runtime', self, :total_runtime_seconds, true) do |runtime_str|
         TestInstance.parse_runtime(runtime_str)
       end,

--- a/app/views/test_instances/search.html.haml
+++ b/app/views/test_instances/search.html.haml
@@ -13,34 +13,6 @@
       Cross-cuts every test run on every computer for every commit
       using a single key-value query language.
 
-  -# Known-broken warning. The search backend
-  -# (`TestInstance.query` in app/models/test_instance.rb) has
-  -# rotted since the SVN→git transition — `version:` queries hit
-  -# the long-gone `Version` model + dropped `mesa_version`
-  -# column and silently fall through (`flash.now[:warning]`).
-  -# Other fields like `test_case:`, `user:`, `commit:` mostly
-  -# still work. The JSON API at `/test_instances/search.json`
-  -# shares the same backend.
-  .rounded-md.border.border-warning.bg-warning-soft.p-3.text-warning-soft-text{ role: "status" }
-    .flex.items-start.gap-2
-      = mesa_icon(:warn, size: 14, css: "mt-0.5 shrink-0")
-      .min-w-0
-        %p.font-semibold{ class: "text-[13px]" } Partial functionality — known rot.
-        %p.mt-1{ class: "text-[12px]" }
-          The query backend has rotted since the SVN → git
-          transition. Some fields still work
-          (#{content_tag(:code, "test_case", class: "font-mono")},
-          #{content_tag(:code, "user", class: "font-mono")},
-          #{content_tag(:code, "commit", class: "font-mono")},
-          #{content_tag(:code, "computer", class: "font-mono")},
-          #{content_tag(:code, "passed", class: "font-mono")}); others
-          (notably #{content_tag(:code, "version", class: "font-mono")}, which depends on the dropped
-          `mesa_version` column + retired `Version` model) silently
-          drop through and return the unfiltered result set. The
-          JSON API (#{content_tag(:code, "/test_instances/search.json", class: "font-mono")})
-          shares the same backend. Repairing the query layer is a
-          separate, deferred task.
-
   -# Search form.
   = form_with url: search_instances_path, method: :get, local: true, class: "rounded-lg border border-border bg-bg-elev p-5 space-y-3", html: { style: "box-shadow: var(--shadow-card-sm);" } do |f|
     %div
@@ -82,7 +54,7 @@
           %p.text-fg-muted
             String multiple pairs together with semicolons:
           %p.mt-2
-            %code.font-mono.text-fg{ class: "rounded-md bg-bg-muted px-2 py-0.5 text-[12px]" } user: Bill Wolf; version: 10000
+            %code.font-mono.text-fg{ class: "rounded-md bg-bg-muted px-2 py-0.5 text-[12px]" } user: Bill Wolf; passed: true
           %p.mt-2.text-fg-muted
             All conditions are combined with AND.
 
@@ -91,7 +63,7 @@
           %p.text-fg-muted
             Comma-separate values for OR, or use a dash for ranges:
           %p.mt-2
-            %code.font-mono.text-fg{ class: "rounded-md bg-bg-muted px-2 py-0.5 text-[12px]" } version: 10000-10200; test_case: wd2, 1M_thermohaline
+            %code.font-mono.text-fg{ class: "rounded-md bg-bg-muted px-2 py-0.5 text-[12px]" } commit_datetime: 2024-01-01-2024-06-30; test_case: wd2, 1M_thermohaline
 
       -# Available fields, two columns.
       %div
@@ -99,14 +71,15 @@
         .grid.gap-x-8.gap-y-1{ class: "grid-cols-1 md:grid-cols-2 text-[13px]" }
           %dl.space-y-2
             = render "field_row", field: "test_case", desc: "Name of a valid test case."
-            = render "field_row", field: "version", desc: "Number of a valid MESA revision."
+            = render "field_row", field: "commit", desc: "Short SHA of a commit (first 7+ characters)."
+            = render "field_row", field: "commit_datetime", desc: "Commit datetime — YYYY-MM-DD. Range supported (e.g. 2024-01-01-2024-06-30)."
             = render "field_row", field: "passed", desc: %q{"t" / "true" / "f" / "false" — match passing or failing instances.}
             = render "field_row", field: "computer", desc: "Name of a computer."
             = render "field_row", field: "user", desc: "Name of a user (maintainer)."
             = render "field_row", field: "date", desc: "Submission date — YYYY/MM/DD, UTC."
             = render "field_row", field: "datetime", desc: "Submission date and time — YYYY/MM/DD hh:mm:ss; append e.g. 'PST' for a non-UTC timezone."
-            = render "field_row", field: "platform", desc: "Computer platform: macOS or linux. No version string."
           %dl.space-y-2
+            = render "field_row", field: "platform", desc: "Computer platform: macOS or linux. No version string."
             = render "field_row", field: "platform_version", desc: "Platform version, e.g. 14.5 or Ubuntu 22.04."
             = render "field_row", field: "rn_runtime / re_runtime / runtime", desc: "Runtime for rn / re scripts or whole test. Integer seconds or '1 hr 30 min', '2.3 hours', etc."
             = render "field_row", field: "rn_RAM / re_RAM", desc: "Peak memory for rn / re scripts, in GB."

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -167,15 +167,14 @@ current state and the design primitives an agent needs.
 
 **Known follow-up — not blocking Phase 5:**
 
-- `TestInstance.query` (the backend for `test_instances#search`
-  and its JSON API counterpart) is partially rotted since the
-  SVN→git transition. Some fields still work (`test_case:`,
-  `user:`, `commit:`, `computer:`, `passed:`); ones tied to the
-  dropped `mesa_version` column / retired `Version` model
-  (notably `version:`) silently fall through. The search page
-  carries a `border-warning` notice so users see the state.
-  Repairing the query layer is a small, contained task — flagged
-  for whenever someone gets to it.
+- ~~`TestInstance.query` rot.~~ Fixed on
+  `fix-test-instances-search`. Dropped the dead `version:`
+  option (depended on the dropped `mesa_version` column /
+  retired `Version` model). Wired up `rn_runtime:` and
+  `re_runtime:` SearchOptions that the help text had been
+  promising. Documented the already-working `commit:` and
+  `commit_datetime:` fields (the latter accepts ranges like
+  `2024-01-01-2024-06-30`), and removed the warning banner.
 
 ## Ongoing — email migration
 

--- a/spec/models/test_instance_query_spec.rb
+++ b/spec/models/test_instance_query_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-# Diagnostic spec for the broken test_instances#search feature.
-# Once we identify the failure mode, this stays as a regression spec.
+# Regression spec for test_instances#search query parsing and execution.
 RSpec.describe TestInstance, '.query', type: :model do
   it 'parses a single key:value pair' do
     expect(TestInstance.split_query('passed: true')).to eq('passed' => 'true')
@@ -28,15 +27,94 @@ RSpec.describe TestInstance, '.query', type: :model do
     expect(failures).to be_empty
   end
 
+  it 'rejects the dropped `version:` key (no mesa_version column)' do
+    _, failures = TestInstance.query('version: 10000')
+    expect(failures).to include('version')
+  end
+
   describe 'each documented search option from the help text' do
-    %w[test_case passed computer user platform platform_version
-       rn_RAM re_RAM threads compiler compiler_version runtime].each do |opt|
+    %w[test_case commit commit_datetime passed computer user platform
+       platform_version rn_RAM re_RAM threads compiler compiler_version
+       runtime rn_runtime re_runtime date datetime].each do |opt|
       it "accepts #{opt} as a valid search key" do
         _, failures = TestInstance.query("#{opt}: foo")
         expect(failures).not_to include(opt),
           "search option `#{opt}` rejected — likely the column it points " \
           "to was renamed or removed"
       end
+    end
+  end
+
+  def make_instance(commit:, computer:, test_case:, **attrs)
+    submission = create(:submission, commit: commit, computer: computer)
+    create(:test_instance, commit: commit, computer: computer,
+                           test_case: test_case, submission: submission, **attrs)
+  end
+
+  describe 'commit-range filtering' do
+    let(:test_case) { create(:test_case) }
+    let(:computer)  { create(:computer) }
+    let(:old_commit) do
+      create(:commit, commit_time: Time.zone.local(2024, 1, 15))
+    end
+    let(:mid_commit) do
+      create(:commit, commit_time: Time.zone.local(2024, 3, 15))
+    end
+    let(:new_commit) do
+      create(:commit, commit_time: Time.zone.local(2024, 8, 15))
+    end
+    let!(:old_instance) do
+      make_instance(commit: old_commit, computer: computer, test_case: test_case)
+    end
+    let!(:mid_instance) do
+      make_instance(commit: mid_commit, computer: computer, test_case: test_case)
+    end
+    let!(:new_instance) do
+      make_instance(commit: new_commit, computer: computer, test_case: test_case)
+    end
+
+    it 'narrows to commits inside a date range' do
+      relation, failures = TestInstance.query(
+        'commit_datetime: 2024-02-01-2024-06-30'
+      )
+      expect(failures).to be_empty
+      expect(relation.to_a).to contain_exactly(mid_instance)
+    end
+
+    it 'matches a single commit by short SHA' do
+      relation, failures = TestInstance.query(
+        "commit: #{mid_commit.short_sha}"
+      )
+      expect(failures).to be_empty
+      expect(relation.to_a).to contain_exactly(mid_instance)
+    end
+  end
+
+  describe 'rn_runtime / re_runtime fields' do
+    let(:test_case) { create(:test_case) }
+    let(:computer)  { create(:computer) }
+    let(:commit)    { create(:commit) }
+    let!(:slow_instance) do
+      make_instance(commit: commit, computer: computer, test_case: test_case,
+                    runtime_seconds: 800, re_time: 200,
+                    total_runtime_seconds: 1000)
+    end
+    let!(:fast_instance) do
+      make_instance(commit: commit, computer: computer, test_case: test_case,
+                    runtime_seconds: 80, re_time: 20,
+                    total_runtime_seconds: 100)
+    end
+
+    it 'rn_runtime filters on runtime_seconds column' do
+      relation, failures = TestInstance.query('rn_runtime: 500-1000')
+      expect(failures).to be_empty
+      expect(relation.to_a).to contain_exactly(slow_instance)
+    end
+
+    it 're_runtime filters on re_time column' do
+      relation, failures = TestInstance.query('re_runtime: 150-300')
+      expect(failures).to be_empty
+      expect(relation.to_a).to contain_exactly(slow_instance)
     end
   end
 


### PR DESCRIPTION
## Summary

The query layer carried a dead `version:` SearchOption that pointed at the dropped `mesa_version` column and silently fell through every search.  Drop it, wire up the `rn_runtime:` and `re_runtime:` SearchOptions that the help text had been promising but the model never provided, and promote the already-working `commit:` and `commit_datetime:` fields into the documented help text (the latter accepts ranges like `2024-01-01-2024-06-30`).  The warning banner at the top of `/test_instances/search` is gone.

The motivating use case is the morning-mailer revival on top of this branch ([#feature-morning-mailer-revival](https://github.com/MESAHub/MESATestHub/tree/feature-morning-mailer-revival)) — anomaly drill-in links land on this search page with a pre-populated `commit_datetime:` window.

## Changes

- [`app/models/test_instance.rb`](https://github.com/MESAHub/MESATestHub/blob/fix-test-instances-search/app/models/test_instance.rb) — drop `version:`, add `rn_runtime:` / `re_runtime:` (mapping to `runtime_seconds` and `re_time` columns).
- [`app/views/test_instances/search.html.haml`](https://github.com/MESAHub/MESATestHub/blob/fix-test-instances-search/app/views/test_instances/search.html.haml) — drop the warning banner, swap `version:` examples for `commit_datetime:` ones, document `commit:` and `commit_datetime:` in the field reference.
- [`app/controllers/test_instances_controller.rb`](https://github.com/MESAHub/MESATestHub/blob/fix-test-instances-search/app/controllers/test_instances_controller.rb) — drop the now-stale rot comment.
- [`spec/models/test_instance_query_spec.rb`](https://github.com/MESAHub/MESATestHub/blob/fix-test-instances-search/spec/models/test_instance_query_spec.rb) — new coverage for the commit-range filter, the new runtime fields, and a guard against `version:` regressing into the documented field list.
- [`docs/roadmap.md`](https://github.com/MESAHub/MESATestHub/blob/fix-test-instances-search/docs/roadmap.md) — move the rot bullet from "known follow-up" to fixed.

## Test plan

- [x] `bundle exec rspec spec/models/test_instance_query_spec.rb` — 33 examples, 0 failures.
- [x] Full suite green (283 examples, 0 failures).
- [ ] Spot-check `/test_instances/search` in prod after deploy: confirm the help text now lists `commit_datetime:`, and that a query like `test_case: 1M_pre_ms_to_wd; commit_datetime: 2024-01-01-2024-06-30` returns results.