### PR TITLE
Fix three digest display bugs surfaced by 2026-05-25 verification

### DIFF
--- a/app/helpers/morning_mailer_helper.rb
+++ b/app/helpers/morning_mailer_helper.rb
@@ -15,11 +15,19 @@ module MorningMailerHelper
     checksums: { label: 'Checksums', klass: 'mesa-badge-warning',
                  style: 'background:#fef6cf; color:#6b4900;' },
     mixed:     { label: 'Mixed',     klass: 'mesa-badge-mixed',
-                 style: 'background:#fef6cf; color:#6b4900;' }
+                 style: 'background:#fef6cf; color:#6b4900;' },
+    # `:untested` is `Commit#status = -1` — the rollup hasn't
+    # finalized (CI run in progress, or no rollup row yet). Renders
+    # in neutral gray so it doesn't masquerade as Passing.
+    untested:  { label: 'Untested',  klass: 'mesa-badge-skipped',
+                 style: 'background:#eceef2; color:#57606a;' }
   }.freeze
 
+  # Falls back to the untested style for any unexpected label rather
+  # than silently labeling unknowns as Passing — the previous behavior
+  # masked status=-1 commits as green.
   def mailer_status_badge(label)
-    style = STATUS_STYLES[label] || STATUS_STYLES[:passing]
+    style = STATUS_STYLES[label] || STATUS_STYLES[:untested]
     badge_pill(text: style[:label], klass: style[:klass], style: style[:style])
   end
 

--- a/app/services/morning_report.rb
+++ b/app/services/morning_report.rb
@@ -70,8 +70,17 @@ class MorningReport
 
   # ===== Inner data classes =====
 
+  # Stand-in for a real Branch on synthetic BranchSections. Must be a
+  # *named* constant so Marshal-based caching can serialize it
+  # (Rails.cache.write → Marshal.dump refuses anonymous classes).
+  SyntheticBranch = Struct.new(:name)
+
   # One branch's worth of commits-tested-in-window, in commit_time DESC.
-  BranchSection = Struct.new(:branch, :commit_summaries, keyword_init: true) do
+  # `synthetic` is true for the catch-all "Unattached commits" group
+  # built from commits that have no branch memberships — typically PR
+  # test-merge commits or commits whose membership row hasn't synced yet.
+  BranchSection = Struct.new(:branch, :commit_summaries, :synthetic,
+                             keyword_init: true) do
     def failing?
       commit_summaries.any?(&:failing?)
     end
@@ -79,10 +88,22 @@ class MorningReport
     def commit_count
       commit_summaries.size
     end
+
+    # Branch name to use when building per-commit URLs. Synthetic
+    # sections don't have a real branch route, so fall back to main —
+    # the commit detail page accepts any branch name and uses it
+    # only as nav context.
+    def link_branch_name
+      synthetic ? "main" : branch.name
+    end
   end
 
   # Per-commit roll-up.  `status` mirrors `Commit#status`:
-  #   0 = passing, 1 = failing, 2 = checksums, 3 = mixed.
+  #   -1 = untested / rollup not finalized (CI run in progress)
+  #    0 = passing
+  #    1 = failing
+  #    2 = checksums
+  #    3 = mixed
   CommitSummary = Struct.new(
     :commit, :status, :tested_count, :computer_count,
     :failing_tccs, :checksum_tccs, :mixed_tccs, :passing_count,
@@ -94,7 +115,7 @@ class MorningReport
       when 1 then :failing
       when 2 then :checksums
       when 3 then :mixed
-      else :unknown
+      else :untested
       end
     end
 
@@ -169,10 +190,18 @@ class MorningReport
     @commits_tested = commits.to_a
 
     # Group commits by branch — a commit may belong to multiple.
+    # Commits with no branch memberships (PR test-merge commits and
+    # in-flight pushes whose membership row hasn't synced) collect
+    # into an "unattached" bucket that renders as a synthetic
+    # section after the real branches.
     branch_to_commits = Hash.new { |h, k| h[k] = [] }
+    unattached_commits = []
     commits.each do |commit|
-      commit.branch_memberships.each do |bm|
-        branch_to_commits[bm.branch] << commit
+      memberships = commit.branch_memberships
+      if memberships.empty?
+        unattached_commits << commit
+      else
+        memberships.each { |bm| branch_to_commits[bm.branch] << commit }
       end
     end
 
@@ -185,7 +214,16 @@ class MorningReport
     @branch_sections = ordered_branches.map do |branch|
       BranchSection.new(
         branch: branch,
-        commit_summaries: branch_to_commits[branch].map { |c| build_summary(c) }
+        commit_summaries: branch_to_commits[branch].map { |c| build_summary(c) },
+        synthetic: false
+      )
+    end
+
+    if unattached_commits.any?
+      @branch_sections << BranchSection.new(
+        branch: SyntheticBranch.new("Unattached commits"),
+        commit_summaries: unattached_commits.map { |c| build_summary(c) },
+        synthetic: true
       )
     end
   end
@@ -330,9 +368,12 @@ class MorningReport
     @release_blocker_count = fetch_release_blocker_count
   end
 
+  # Returns the count of open issues labeled `release-blocker` on the
+  # MESAHub/mesa repo, or nil when we can't reach GitHub (no token, API
+  # error, or running in the test environment). The view distinguishes
+  # nil from 0 so subscribers can tell "couldn't check" apart from
+  # "checked, nothing pending."
   def fetch_release_blocker_count
-    # Hit GitHub only when there's a token configured and we're not in
-    # the test environment; the spec suite doesn't need real API traffic.
     return nil if Rails.env.test?
     return nil if ENV['GIT_TOKEN'].to_s.empty?
 

--- a/app/views/layouts/morning_mailer.html.haml
+++ b/app/views/layouts/morning_mailer.html.haml
@@ -37,6 +37,7 @@
         .mesa-badge-warning { background:rgba(210,153,34,0.18) !important; color:#e3b341 !important; }
         .mesa-badge-info    { background:rgba(107,130,255,0.20) !important; color:#a8b6ff !important; }
         .mesa-badge-mixed   { background:rgba(210,153,34,0.18) !important; color:#e3b341 !important; }
+        .mesa-badge-skipped { background:rgba(110,118,129,0.20) !important; color:#9198a1 !important; }
         .mesa-stat-num { color:#e6edf3 !important; }
         .mesa-anomaly-card { background:rgba(248,81,73,0.06) !important; border-color:rgba(248,81,73,0.30) !important; }
         .mesa-wordmark-text { color:#e6edf3 !important; }

--- a/app/views/morning_mailer/daily.html.haml
+++ b/app/views/morning_mailer/daily.html.haml
@@ -66,14 +66,17 @@
                     %div.mesa-stat-num{ style: "margin-top:4px; font-size:24px; font-weight:600; color:#{anomaly_count.zero? ? '#1f2328' : '#a40e26'};" }
                       = anomaly_count
 
-      - if @report.release_blocker_count
-        %div.mesa-fg-muted{ style: "margin-top:14px; font-size:12px; color:#57606a;" }
-          - if @report.release_blocker_count.zero?
-            No open release-blocker issues.
-          - else
-            %strong{ style: "color:#a40e26;" }
-              = pluralize(@report.release_blocker_count, 'open release-blocker')
-            on GitHub.
+      %div.mesa-fg-muted{ style: "margin-top:14px; font-size:12px; color:#57606a;" }
+        - case @report.release_blocker_count
+        - when nil
+          %span.mesa-fg-subtle{ style: "color:#8b949e;" }
+            Release blockers: couldn't check (no GitHub API access in this environment).
+        - when 0
+          No open release-blocker issues on GitHub.
+        - else
+          %strong{ style: "color:#a40e26;" }
+            = pluralize(@report.release_blocker_count, 'open release-blocker')
+          on GitHub.
 
 -# ===== Anomalies =====
 - if @report.any_anomalies?
@@ -151,6 +154,9 @@
                 = section.branch.name
               %td.mesa-fg-muted{ style: "color:#57606a; font-size:11px; text-align:right;" }
                 = pluralize(section.commit_count, 'commit')
+          - if section.synthetic
+            %div.mesa-fg-muted{ style: "margin-top:4px; font-size:11px; color:#8b949e;" }
+              Commits with no branch membership — typically PR test-merge commits, or pushes whose branch sync hasn't landed yet.
 
       - section.commit_summaries.each_with_index do |cs, i|
         %tr
@@ -164,7 +170,7 @@
                     %tr
                       %td{ valign: "top", style: "padding-right:10px;" }
                         %div
-                          = link_to mailer_message_excerpt(cs.commit), commit_url(branch: section.branch.name, sha: cs.commit.short_sha), class: "mesa-link mesa-fg", style: "color:#1f2328; text-decoration:none; font-size:14px; font-weight:500;"
+                          = link_to mailer_message_excerpt(cs.commit), commit_url(branch: section.link_branch_name, sha: cs.commit.short_sha), class: "mesa-link mesa-fg", style: "color:#1f2328; text-decoration:none; font-size:14px; font-weight:500;"
                         %div.mesa-fg-muted{ style: "margin-top:4px; font-size:12px; color:#57606a;" }
                           = mailer_sha_pill(cs.commit)
                           %span{ style: "padding:0 6px; color:#8b949e;" } ·
@@ -187,7 +193,7 @@
                             - else :passing
                           = mailer_status_badge(tcc_status_key)
                           %span{ style: "padding-left:8px;" }
-                            = link_to tcc.test_case.name, mailer_test_case_commit_url(section.branch.name, tcc, cs.commit), class: "mesa-link mesa-fg", style: "color:#1f2328; text-decoration:none; font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px;"
+                            = link_to tcc.test_case.name, mailer_test_case_commit_url(section.link_branch_name, tcc, cs.commit), class: "mesa-link mesa-fg", style: "color:#1f2328; text-decoration:none; font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px;"
                       - if cs.problem_tccs.size > 8
                         %div.mesa-fg-muted{ style: "padding-top:4px; font-size:11px; color:#8b949e;" }
                           (+ #{cs.problem_tccs.size - 8} more)

--- a/spec/services/morning_report_spec.rb
+++ b/spec/services/morning_report_spec.rb
@@ -71,6 +71,69 @@ RSpec.describe MorningReport, type: :model do
                                                    feature_commit.id)
       end
     end
+
+    context 'with a branchless commit (PR test-merge, etc.)' do
+      let(:main_branch) { create(:branch, name: 'main') }
+      let(:test_case)   { create(:test_case) }
+      let(:computer)    { create(:computer) }
+      let(:in_window_time) { as_of - 2.hours }
+      let(:branch_commit) { create(:commit, commit_time: in_window_time) }
+      let(:branchless_commit) do
+        create(:commit, commit_time: in_window_time - 1.minute)
+      end
+
+      before do
+        create(:branch_membership, branch: main_branch, commit: branch_commit)
+        # branchless_commit deliberately has no membership.
+        make_instance(commit: branch_commit, computer: computer,
+                      test_case: test_case, created_at: in_window_time)
+        make_instance(commit: branchless_commit, computer: computer,
+                      test_case: test_case, created_at: in_window_time)
+      end
+
+      it 'still counts the branchless commit in commits_tested' do
+        report = described_class.new(as_of: as_of).build
+        expect(report.commits_tested.map(&:id))
+          .to contain_exactly(branch_commit.id, branchless_commit.id)
+      end
+
+      it 'appends a synthetic "Unattached commits" section after real branches' do
+        report = described_class.new(as_of: as_of).build
+        section_names = report.branch_sections.map { |s| s.branch.name }
+        expect(section_names).to eq(['main', 'Unattached commits'])
+        synthetic = report.branch_sections.last
+        expect(synthetic.synthetic).to be(true)
+        expect(synthetic.commit_summaries.map { |cs| cs.commit.id })
+          .to eq([branchless_commit.id])
+      end
+
+      it 'falls back to "main" for URL building on the synthetic section' do
+        report = described_class.new(as_of: as_of).build
+        synthetic = report.branch_sections.last
+        expect(synthetic.link_branch_name).to eq('main')
+      end
+    end
+  end
+
+  describe 'CommitSummary#status_label' do
+    let(:commit) { create(:commit) }
+
+    it 'returns :untested (not :unknown / :passing) for status = -1' do
+      summary = described_class::CommitSummary.new(
+        commit: commit, status: -1, tested_count: 5, computer_count: 1,
+        failing_tccs: [], checksum_tccs: [], mixed_tccs: [], passing_count: 5
+      )
+      expect(summary.status_label).to eq(:untested)
+      expect(summary.failing?).to be(false)
+    end
+
+    it 'returns :passing for status = 0' do
+      summary = described_class::CommitSummary.new(
+        commit: commit, status: 0, tested_count: 5, computer_count: 1,
+        failing_tccs: [], checksum_tccs: [], mixed_tccs: [], passing_count: 5
+      )
+      expect(summary.status_label).to eq(:passing)
+    end
   end
 
   describe 'anomaly detection' do


### PR DESCRIPTION
## Summary

Three bugs we found by cross-checking the rendered digest against the DB for `2026-05-25`:

### 1. `status=-1` commits rendered as green "Passing"

`Commit#status = -1` means the per-commit rollup hasn't finalized — typically a CI run is in progress, not all expected test cases have reported, or the commit just hasn't been touched yet. [`mailer_status_badge`](app/helpers/morning_mailer_helper.rb) fell through `STATUS_STYLES[label] || STATUS_STYLES[:passing]` for the `:unknown` label and silently rendered them green. Two of the nine commits in the 2026-05-25 window had this and looked passing.

Fixed by adding an `:untested` badge style (neutral gray, matching the `--color-skipped` token in light + dark mode), routing `status=-1` through `CommitSummary#status_label` to `:untested`, and making the fallback land on `:untested` too so future drift can't silently re-create the bug.

### 2. Branchless commits counted in the headline but never displayed

Three of the nine commits in the 2026-05-25 window had no `branch_memberships` row:

- 2 were PR test-merge commits (`Merge <sha> into <sha>` messages)
- 1 was an in-flight push to a branch whose membership row hadn't synced

The headline counted them ("9 commits tested") but [`MorningReport#load_commits`](app/services/morning_report.rb) iterates `commit.branch_memberships` to build the per-branch sections, so commits with zero memberships dropped silently. Subscribers saw a number that didn't match the cards.

Fixed by appending a synthetic `BranchSection` (named `"Unattached commits"`, with a `synthetic: true` flag) after the real branches. `BranchSection#link_branch_name` returns `"main"` for synthetic sections so commit / test-case URLs stay routable. Section gets a short subtitle explaining what these commits are — typically PR merge-tests.

`SyntheticBranch` is a named Struct constant rather than `Struct.new(:name).new(…)` so Rails' Marshal-based cache can serialize the report.

### 3. Release-blocker line hidden when the count is nil

`MorningReport#fetch_release_blocker_count` returns nil when `GIT_TOKEN` is unset or the GitHub API errors. The template had `if @report.release_blocker_count` around the entire block, so the line disappeared completely instead of telling the reader anything.

Fixed: always render the line, with three states — `nil` → "couldn't check (no GitHub API access in this environment)", `0` → "No open release-blocker issues", `>0` → bold red with the count.

## Test plan

- [x] `bundle exec rspec` — 301 examples, 0 failures (up from 296).
- [x] Visually verified at `/morning_report?date=2026-05-25&refresh=1` against the freshly-pulled production DB: all 9 commits now appear (6 across real branches + 3 in the new "Unattached commits" section); `status=-1` commits show gray "Untested" badges; the release-blocker line shows the dev-mode notice.
- [ ] After deploy: the release-blocker line should report the live count in production where `GIT_TOKEN` is set.