### PR TITLE
Add Build badge and switch to 'X of Y computers complete'

### DIFF
--- a/app/helpers/morning_mailer_helper.rb
+++ b/app/helpers/morning_mailer_helper.rb
@@ -8,19 +8,33 @@ module MorningMailerHelper
   # mailer layout's dark-mode @media rules; the inline style is the
   # always-on light-mode look.
   STATUS_STYLES = {
-    passing:   { label: 'Passing',   klass: 'mesa-badge-success',
+    passing:   { label: 'Tests: Pass',      klass: 'mesa-badge-success',
                  style: 'background:#d8f5df; color:#0a5825;' },
-    failing:   { label: 'Failing',   klass: 'mesa-badge-danger',
+    failing:   { label: 'Tests: Fail',      klass: 'mesa-badge-danger',
                  style: 'background:#ffe4e6; color:#a40e26;' },
-    checksums: { label: 'Checksums', klass: 'mesa-badge-warning',
+    checksums: { label: 'Tests: Checksums', klass: 'mesa-badge-warning',
                  style: 'background:#fef6cf; color:#6b4900;' },
-    mixed:     { label: 'Mixed',     klass: 'mesa-badge-mixed',
+    mixed:     { label: 'Tests: Mixed',     klass: 'mesa-badge-mixed',
                  style: 'background:#fef6cf; color:#6b4900;' },
     # `:untested` is `Commit#status = -1` — the rollup hasn't
     # finalized (CI run in progress, or no rollup row yet). Renders
     # in neutral gray so it doesn't masquerade as Passing.
-    untested:  { label: 'Untested',  klass: 'mesa-badge-skipped',
+    untested:  { label: 'Tests: Pending',   klass: 'mesa-badge-skipped',
                  style: 'background:#eceef2; color:#57606a;' }
+  }.freeze
+
+  # Separate from STATUS_STYLES so a "no compile status reported"
+  # commit can suppress the badge entirely without affecting the
+  # tests-status fallback.
+  BUILD_STYLES = {
+    build_ok:    { label: 'Build: OK',    klass: 'mesa-badge-success',
+                   style: 'background:#d8f5df; color:#0a5825;' },
+    build_fail:  { label: 'Build: Fail',  klass: 'mesa-badge-danger',
+                   style: 'background:#ffe4e6; color:#a40e26;' },
+    build_mixed: { label: 'Build: Mixed', klass: 'mesa-badge-mixed',
+                   style: 'background:#fef6cf; color:#6b4900;' }
+    # :build_none intentionally absent — render nothing rather than
+    # a confusing placeholder when no compilation status came in.
   }.freeze
 
   # Falls back to the untested style for any unexpected label rather
@@ -28,6 +42,32 @@ module MorningMailerHelper
   # masked status=-1 commits as green.
   def mailer_status_badge(label)
     style = STATUS_STYLES[label] || STATUS_STYLES[:untested]
+    badge_pill(text: style[:label], klass: style[:klass], style: style[:style])
+  end
+
+  # Returns build-status badge HTML, or an empty (safe) string when no
+  # build status is available so the layout collapses gracefully.
+  def mailer_build_badge(label)
+    style = BUILD_STYLES[label]
+    return ''.html_safe unless style
+
+    badge_pill(text: style[:label], klass: style[:klass], style: style[:style])
+  end
+
+  # Short-form badges for the inline per-test-case-commit lists
+  # (rendered next to a test-case name, where the "Tests:" prefix
+  # used by the commit-level status badge is redundant).
+  TCC_STATUS_STYLES = {
+    failing:   { label: 'Fail',      klass: 'mesa-badge-danger',
+                 style: 'background:#ffe4e6; color:#a40e26;' },
+    checksums: { label: 'Checksums', klass: 'mesa-badge-warning',
+                 style: 'background:#fef6cf; color:#6b4900;' },
+    mixed:     { label: 'Mixed',     klass: 'mesa-badge-mixed',
+                 style: 'background:#fef6cf; color:#6b4900;' }
+  }.freeze
+
+  def mailer_tcc_badge(label)
+    style = TCC_STATUS_STYLES[label] || TCC_STATUS_STYLES[:failing]
     badge_pill(text: style[:label], klass: style[:klass], style: style[:style])
   end
 

--- a/app/services/morning_report.rb
+++ b/app/services/morning_report.rb
@@ -98,14 +98,24 @@ class MorningReport
     end
   end
 
-  # Per-commit roll-up.  `status` mirrors `Commit#status`:
+  # Per-commit roll-up.
+  #
+  # `status` mirrors `Commit#status` (the test rollup):
   #   -1 = untested / rollup not finalized (CI run in progress)
-  #    0 = passing
-  #    1 = failing
-  #    2 = checksums
-  #    3 = mixed
+  #    0 = passing, 1 = failing, 2 = checksums, 3 = mixed
+  #
+  # `build_status` mirrors `Commit#compilation_status` (compile rollup):
+  #   -1 = no compile status reported
+  #    0 = compiles everywhere, 1 = fails everywhere, 2 = mixed
+  #
+  # `computer_count` is the count of distinct (computer × spec)
+  # submissions on this commit.  `complete_computer_count` is how
+  # many of those actually ran all test cases.  Drive-by submitters
+  # that ran 1/106 tests still bump `computer_count` but not
+  # `complete_computer_count`, so the digest reports both.
   CommitSummary = Struct.new(
-    :commit, :status, :tested_count, :computer_count,
+    :commit, :status, :build_status, :tested_count,
+    :computer_count, :complete_computer_count,
     :failing_tccs, :checksum_tccs, :mixed_tccs, :passing_count,
     keyword_init: true
   ) do
@@ -119,8 +129,18 @@ class MorningReport
       end
     end
 
+    def build_label
+      case build_status
+      when 0 then :build_ok
+      when 1 then :build_fail
+      when 2 then :build_mixed
+      else :build_none
+      end
+    end
+
     def failing?
-      status_label == :failing || status_label == :mixed
+      status_label == :failing || status_label == :mixed ||
+        build_label == :build_fail || build_label == :build_mixed
     end
 
     def problem_tccs
@@ -233,9 +253,11 @@ class MorningReport
     CommitSummary.new(
       commit: commit,
       status: commit.status,
+      build_status: commit.compilation_status,
       tested_count: commit.passed_count.to_i + commit.failed_count.to_i +
                     commit.mixed_count.to_i + commit.checksum_count.to_i,
       computer_count: commit.computer_count.to_i,
+      complete_computer_count: commit.complete_computer_count.to_i,
       passing_count: commit.passed_count.to_i,
       failing_tccs: tccs.select { |t| t.status == 1 },
       checksum_tccs: tccs.select { |t| t.status == 2 },

--- a/app/views/morning_mailer/daily.html.haml
+++ b/app/views/morning_mailer/daily.html.haml
@@ -176,10 +176,14 @@
                           %span{ style: "padding:0 6px; color:#8b949e;" } ·
                           = cs.commit.author
                           %span{ style: "padding:0 6px; color:#8b949e;" } ·
-                          = pluralize(cs.tested_count, 'test')
-                          on
-                          = pluralize(cs.computer_count, 'computer')
+                          - if cs.complete_computer_count == cs.computer_count
+                            #{pluralize(cs.tested_count, 'test')} on #{pluralize(cs.computer_count, 'computer')}
+                          - else
+                            #{pluralize(cs.tested_count, 'test')} · #{cs.complete_computer_count} of #{cs.computer_count} computers complete
                       %td{ valign: "top", align: "right", style: "white-space:nowrap;" }
+                        - if cs.build_label != :build_none
+                          %div{ style: "margin-bottom:4px;" }
+                            = mailer_build_badge(cs.build_label)
                         = mailer_status_badge(cs.status_label)
 
                   - if cs.problem_tccs.any?
@@ -190,8 +194,8 @@
                             - when 1 then :failing
                             - when 2 then :checksums
                             - when 3 then :mixed
-                            - else :passing
-                          = mailer_status_badge(tcc_status_key)
+                            - else :failing
+                          = mailer_tcc_badge(tcc_status_key)
                           %span{ style: "padding-left:8px;" }
                             = link_to tcc.test_case.name, mailer_test_case_commit_url(section.link_branch_name, tcc, cs.commit), class: "mesa-link mesa-fg", style: "color:#1f2328; text-decoration:none; font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px;"
                       - if cs.problem_tccs.size > 8

--- a/spec/services/morning_report_spec.rb
+++ b/spec/services/morning_report_spec.rb
@@ -115,24 +115,40 @@ RSpec.describe MorningReport, type: :model do
     end
   end
 
-  describe 'CommitSummary#status_label' do
+  describe 'CommitSummary' do
     let(:commit) { create(:commit) }
 
-    it 'returns :untested (not :unknown / :passing) for status = -1' do
-      summary = described_class::CommitSummary.new(
-        commit: commit, status: -1, tested_count: 5, computer_count: 1,
+    def summary(overrides = {})
+      described_class::CommitSummary.new({
+        commit: commit, status: 0, build_status: 0, tested_count: 5,
+        computer_count: 1, complete_computer_count: 1,
         failing_tccs: [], checksum_tccs: [], mixed_tccs: [], passing_count: 5
-      )
-      expect(summary.status_label).to eq(:untested)
-      expect(summary.failing?).to be(false)
+      }.merge(overrides))
+    end
+
+    it 'returns :untested (not :unknown / :passing) for status = -1' do
+      s = summary(status: -1)
+      expect(s.status_label).to eq(:untested)
+      expect(s.failing?).to be(false)
     end
 
     it 'returns :passing for status = 0' do
-      summary = described_class::CommitSummary.new(
-        commit: commit, status: 0, tested_count: 5, computer_count: 1,
-        failing_tccs: [], checksum_tccs: [], mixed_tccs: [], passing_count: 5
-      )
       expect(summary.status_label).to eq(:passing)
+    end
+
+    it 'maps build_status to a :build_ok / :build_fail / :build_mixed / :build_none label' do
+      expect(summary(build_status: 0).build_label).to eq(:build_ok)
+      expect(summary(build_status: 1).build_label).to eq(:build_fail)
+      expect(summary(build_status: 2).build_label).to eq(:build_mixed)
+      expect(summary(build_status: -1).build_label).to eq(:build_none)
+    end
+
+    it 'flags failing? on build failure even when tests are still pending' do
+      expect(summary(status: -1, build_status: 1).failing?).to be(true)
+    end
+
+    it 'flags failing? on mixed build status' do
+      expect(summary(status: 0, build_status: 2).failing?).to be(true)
     end
   end
 


### PR DESCRIPTION
Re-opened from [#83](https://github.com/MESAHub/MESATestHub/pull/83) — the original PR got auto-closed when its base branch (`fix-digest-display-issues`, the head of [#82](https://github.com/MESAHub/MESATestHub/pull/82)) was deleted on merge, and GitHub refused to reopen + re-target. Same commits, now stacked directly on `master`.

---

## Summary

Two issues surfaced by the 2026-05-25 cross-check — both cases where the digest hid information the data actually had.

### 1. A single status pill was hiding compile failures

The previous design folded everything into one Pass/Fail/Mixed/Checksums/Pending pill, which is wrong when build status and test status disagree.  Concrete case from 2026-05-25:

| SHA | Tests | Build | Old badge | New badges |
|---|---|---|---|---|
| `5065b6d` | all 106 pass on 1/2 computers | Mixed (one computer couldn't compile) | "Passing" | Build: Mixed + Tests: Pass |
| `fb1f429` | 106 fail | Mixed | "Failing" | Build: Mixed + Tests: Fail |
| `0671b8f` | drive-by 1/106 | unknown | "Pending" | (no build badge) + Tests: Pending |

`Commit#compilation_status` already returns `-1 / 0 / 1 / 2` for none-reported / OK / Fail / Mixed.  `MorningReport::CommitSummary` carries it as `build_status`, the helper renders a separate `mailer_build_badge`, and the template stacks the two badges vertically on the right edge of each commit card.  `:build_none` (no compile status reported) suppresses the badge entirely rather than rendering a confusing placeholder.

`CommitSummary#failing?` now flags `Build: Fail` and `Build: Mixed` in addition to test failures, so the "Need attention" headline picks up build problems too — went from 2 to 3 on 2026-05-25 because `5065b6d` had a Mixed build that the old digest was swallowing.

### 2. "N computers" was over-counting drive-bys

`commit.computer_count` is the number of distinct (computer × spec) submissions, including computers that submitted 1 of 106 tests and bailed.  `complete_computer_count` is the number that actually finished — that's what matters for "did this commit really get tested?"

Concrete case: `250d865` reads "1 of 3 computers complete" instead of the old "3 computers" — one computer ran all 106 tests, one ran 105, one was a drive-by.

The subtitle keeps the shorter "N tests on M computers" form when all participating computers finished, and switches to "N tests · X of Y computers complete" when they don't agree.

### Other small things

- Tests-status pill labels are now `Tests: Pass / Fail / Mixed / Checksums / Pending` so they read alongside the new Build badge.
- Per-test-case inline pills use a shorter `TCC_STATUS_STYLES` (`Fail / Checksums / Mixed`) — the "Tests:" prefix is redundant in a list of test cases.

## Test plan

- [x] `bundle exec rspec` — 304 examples, 0 failures (up from 301). 3 new CommitSummary specs cover the build-status label mapping and the `failing?` build-failure paths.
- [x] Verified at `/morning_report?date=2026-05-25&refresh=1` against fresh prod data — all 9 commits' Build / Tests badges and "X of Y" counts match the underlying `Commit#compilation_status` and `complete_computer_count` columns.