### PR TITLE
Fix mailer SMTP timeout + lock cron to 8 AM ET across DST

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,16 +1,21 @@
-# Provider-agnostic SMTP wiring. Defaults to Resend (smtp.resend.com)
-# because that's what production runs, but every value is overridable
-# via env vars so a future provider swap is a config change rather
-# than a code change.
+# Provider-agnostic SMTP wiring. Defaults to Resend
+# (smtp.resend.com) because that's what production runs, but every
+# value is overridable via env vars so a future provider swap is a
+# config change rather than a code change.
 #
 # Required env vars in production:
 #   SMTP_PASSWORD  — for Resend, the API key value
 #                    (or set RESEND_API_KEY and we'll pick it up)
 #
-# Optional (defaults match Resend's SMTP endpoint):
+# Optional (defaults match Resend's STARTTLS endpoint):
 #   SMTP_HOST  — default smtp.resend.com
-#   SMTP_PORT  — default 465 (implicit TLS)
+#   SMTP_PORT  — default 587 (STARTTLS); 465 / 2465 for implicit TLS
 #   SMTP_USER  — default 'resend'
+#
+# TLS strategy is auto-picked by port: 465 / 2465 use implicit TLS
+# (TLS handshake on connect), every other port uses STARTTLS (plain
+# socket then upgrade). Default is 587 because some cloud providers
+# (Railway included) only allow outbound STARTTLS, not implicit TLS.
 class ApplicationMailer < ActionMailer::Base
   # From-address domain (testhub.mesastar.org) is the one we verify
   # with the email provider. Any future mailer overrides this via
@@ -19,13 +24,20 @@ class ApplicationMailer < ActionMailer::Base
   layout 'mailer'
 end
 
+smtp_port = ENV.fetch('SMTP_PORT', '587').to_i
+tls_options =
+  if [465, 2465].include?(smtp_port)
+    { tls: true }
+  else
+    { enable_starttls_auto: true }
+  end
+
 ApplicationMailer.smtp_settings = {
   address:        ENV.fetch('SMTP_HOST', 'smtp.resend.com'),
-  port:           ENV.fetch('SMTP_PORT', '465').to_i,
+  port:           smtp_port,
   user_name:      ENV.fetch('SMTP_USER', 'resend'),
   password:       ENV['SMTP_PASSWORD'] || ENV['RESEND_API_KEY'],
   domain:         'testhub.mesastar.org',
-  authentication: :plain,
-  tls:            true
-}
+  authentication: :plain
+}.merge(tls_options)
 ApplicationMailer.delivery_method = :smtp

--- a/docs/morning-mailer.md
+++ b/docs/morning-mailer.md
@@ -66,10 +66,16 @@ off for your use case.
 ## Email provider — Resend
 
 SMTP wiring in [`app/mailers/application_mailer.rb`](../app/mailers/application_mailer.rb)
-is provider-agnostic: it defaults to Resend's SMTP endpoint
-(`smtp.resend.com:465`, implicit TLS, username `resend`) but every
-value is overridable via env vars.  Swapping to a different
-provider is a config change, not a code change.
+is provider-agnostic: it defaults to Resend's STARTTLS SMTP endpoint
+(`smtp.resend.com:587`, username `resend`) but every value is
+overridable via env vars.  Swapping to a different provider is a
+config change, not a code change.
+
+The TLS strategy is auto-picked by port: 465 / 2465 use implicit
+TLS (handshake on connect); every other port (587, 2587, 25, …)
+uses STARTTLS.  Default is 587 because some cloud hosts —
+Railway among them — block outbound implicit-TLS SMTP but allow
+STARTTLS.
 
 ### Required env vars (cron service)
 
@@ -77,13 +83,13 @@ provider is a config change, not a code change.
 |---|---|---|
 | `SMTP_PASSWORD` *or* `RESEND_API_KEY` | — | API key from Resend's dashboard. The code reads `SMTP_PASSWORD` first, then falls back to `RESEND_API_KEY`, so either name works. |
 | `SMTP_HOST` | `smtp.resend.com` | SMTP endpoint hostname. |
-| `SMTP_PORT` | `465` | Use 465 for implicit TLS (matches the `tls: true` setting), or override to 587/2587 for STARTTLS (would also need a code tweak to swap `tls:` for `enable_starttls_auto:`). |
+| `SMTP_PORT` | `587` | 587 (STARTTLS) or 2587 (STARTTLS alt) work on Railway. 465 / 2465 (implicit TLS) may be blocked; only use those if you've confirmed outbound 465 works for your host. |
 | `SMTP_USER` | `resend` | Resend uses the literal username `resend` for every account; only the password (API key) identifies you. |
 | `DATABASE_URL` | — | Reference the Railway Postgres service: `${{Postgres.DATABASE_URL}}`. |
 | `SECRET_KEY_BASE` | — | Required for Rails to boot. Reference the web service's: `${{MESATestHub.SECRET_KEY_BASE}}`. |
 | `GIT_TOKEN` | — | Optional but recommended — without it, the digest shows "couldn't check" for the release-blocker line. Reference the web service's: `${{MESATestHub.GIT_TOKEN}}`. |
 | `RAILS_ENV` | — | Set to `production`. |
-| `TZ` | UTC | Set to `America/New_York` so the cron schedule evaluates in Eastern Time (DST-safe). |
+| `TZ` | UTC | Set to `America/New_York` so `Time.now` reads Eastern inside the rake task's "is it 8 AM yet?" guard. Note: the Railway cron *scheduler* itself always evaluates in UTC — see the cron section below. |
 
 ### Domain verification in Resend
 
@@ -106,8 +112,12 @@ is unchanged.
 ## Scheduling — 8 AM US Eastern
 
 The intended cadence is **8:00 AM US Eastern Time** every day.
-Daylight Saving makes that a moving UTC target, so configure cron
-with the `TZ` env var rather than encoding the offset.
+Railway's cron scheduler evaluates schedules in UTC regardless of
+the service's `TZ` env var, and 8 AM ET moves between 12 UTC (EDT)
+and 13 UTC (EST) twice a year.  To get a stable 8 AM ET delivery
+across DST without manual schedule edits, we fire **twice** in UTC
+and let the rake task itself decide whether it's actually 8 AM
+Eastern.
 
 ### Railway cron trigger
 
@@ -115,15 +125,18 @@ On the cron service:
 
 1. **Variables** → set everything in the table above.
 2. **Settings** → set the two fields:
-   - **Cron Schedule**: `0 8 * * *`
+   - **Cron Schedule**: `0 12,13 * * *` (fires at 12:00 UTC *and* 13:00 UTC)
    - **Custom Start Command**: `bundle exec rake morning_mailer:daily`
 
    When a Cron Schedule is set, Railway runs the service as a
    one-shot job and uses Custom Start Command as the command for
    each invocation.
-3. Combined with `TZ=America/New_York` from the variables, Railway
-   evaluates `0 8 * * *` as 8 AM Eastern and the schedule tracks
-   DST automatically.
+3. `lib/tasks/morning_mailer.rake` checks `Time.now.in_time_zone('America/New_York').hour`
+   on every run and **exits without sending** when the local
+   Eastern hour isn't 8.  Net effect: during EDT (UTC-4) the 12 UTC
+   fire delivers and the 13 UTC fire skips; during EST (UTC-5) the
+   12 UTC fire skips and the 13 UTC fire delivers.  Always 8 AM ET,
+   no DST babysitting.
 
 The cron service is a separate Railway service from the web app —
 both deploy from this repo, but only the web service has a public
@@ -133,8 +146,12 @@ rake task once, and exits.
 ### Local manual send
 
 ```
-DISABLE_SPRING=1 bundle exec rake morning_mailer:daily
+FORCE=1 DISABLE_SPRING=1 bundle exec rake morning_mailer:daily
 ```
+
+The `FORCE=1` env var bypasses the 8-AM-Eastern guard so the task
+sends regardless of local time.  Same flag works for on-Railway
+manual fires from the dashboard.
 
 (Needs the SMTP env vars set locally too — easiest is a `.env`
 that mirrors the Railway cron service's variables.)

--- a/lib/tasks/morning_mailer.rake
+++ b/lib/tasks/morning_mailer.rake
@@ -1,6 +1,17 @@
 namespace :morning_mailer do
-  desc 'Send the daily MESA Test Hub digest to mesa-developers.'
+  desc 'Send the daily MESA Test Hub digest to mesa-developers ' \
+       '(only fires when local clock reads 8 AM Eastern; set FORCE=1 ' \
+       'to send regardless).'
   task daily: :environment do
+    eastern_hour = Time.now.in_time_zone('America/New_York').hour
+    force = ENV['FORCE'] == '1'
+
+    if eastern_hour != 8 && !force
+      puts "Skipping: #{Time.now.in_time_zone('America/New_York').strftime('%H:%M %Z')} " \
+           "is not 8 AM Eastern. Set FORCE=1 to send anyway."
+      next
+    end
+
     puts 'Sending out morning digest...'
     MorningMailer.daily.deliver_now
     puts 'done.'


### PR DESCRIPTION
## Summary

After [#85](https://github.com/MESAHub/MESATestHub/pull/85) merged, the first manual cron fire on Railway hit `Net::OpenTimeout` on the `smtp.resend.com:465` connect. Root cause: Railway blocks outbound implicit-TLS SMTP (port 465). STARTTLS on 587 works.

Two related fixes in one PR:

### 1. SMTP timeout → switch default port + auto-pick TLS strategy

- `SMTP_PORT` defaults to `587` (was `465`).
- TLS strategy is now derived from the port at boot:
  - `465` or `2465` → implicit TLS (`tls: true`) — handshake on connect
  - everything else (`587`, `2587`, `25`, …) → STARTTLS (`enable_starttls_auto: true`) — plaintext socket then upgrade

Setting `SMTP_PORT=465` flips back to implicit TLS in one env var if Railway ever opens port 465 (or for hosts that allow it). No code change needed to switch.

### 2. Cron schedule → fire twice in UTC, let the task decide

Railway's cron scheduler evaluates expressions in UTC regardless of the service's `TZ` env var. 8 AM Eastern lands at 12 UTC during EDT and 13 UTC during EST, so a single fixed UTC time can't stay locked to 8 AM ET across DST.

Fix: schedule `0 12,13 * * *` (fires twice daily UTC), and the rake task itself checks `Time.now.in_time_zone('America/New_York').hour == 8` before delivering. The other fire is a fast no-op (Rails boots, sees it's not 8 ET, exits — costs maybe a minute of container time).

`FORCE=1` env var bypasses the guard for manual testing — same flag works for `bundle exec rake morning_mailer:daily` runs from the Railway dashboard.

## Test plan

- [x] `bundle exec rspec` — 304 examples, 0 failures (no test changes needed; the rake-task guard isn't covered by the existing mailer spec, but the SMTP-config change is dead-code in `:test` delivery mode).
- [ ] After deploy: update the cron service's **Cron Schedule** to `0 12,13 * * *` and **SMTP_PORT** to `587` (or unset it — 587 is now the default). Manual fire with `FORCE=1 bundle exec rake morning_mailer:daily` should deliver successfully.
- [ ] Confirm Resend dashboard shows the manually-fired email as delivered.
- [ ] Verify the next scheduled fire (12 UTC / 13 UTC depending on DST) delivers and the other one skips with a "not 8 AM Eastern" log line.