### PR TITLE
Switch mailer from SMTP to Resend HTTP API (Railway blocks SMTP)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,11 @@ gem 'faraday-http-cache'
 gem 'faraday-retry'
 gem 'github_webhook', '~> 1.4'
 
+# Email delivery via Resend's HTTPS API. Used instead of SMTP
+# because Railway (and many other cloud hosts) block outbound
+# SMTP entirely.
+gem 'resend'
+
 # Frontend stack. Tailwind for styling, Turbo + Stimulus for
 # behavior, Importmap for ES module loading without a JS build
 # step. HAML is the template engine. Sprockets-rails serves the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
     concurrent-ruby (1.3.4)
     connection_pool (3.0.2)
     crass (1.0.6)
+    csv (3.3.5)
     database_cleaner (2.1.0)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.2.2)
@@ -163,6 +164,10 @@ GEM
       railties (>= 5.1)
     heapy (0.2.0)
       thor
+    httparty (0.24.2)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.3)
@@ -218,6 +223,8 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.7.2)
+    multi_xml (0.9.1)
+      bigdecimal (>= 3.1, < 5)
     net-http (0.9.1)
       uri (>= 0.11.1)
     net-imap (0.6.4)
@@ -321,6 +328,9 @@ GEM
       io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
+    resend (1.3.0)
+      base64
+      httparty (>= 0.22.0)
     rexml (3.4.4)
     rouge (4.1.3)
     rspec-core (3.12.2)
@@ -447,6 +457,7 @@ DEPENDENCIES
   rack-cors (>= 2.0.2)
   rails (~> 8.0.0)
   rails-html-sanitizer (~> 1.6.2)
+  resend
   rexml (>= 3.3.9)
   rspec-rails
   selenium-webdriver

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,43 +1,29 @@
-# Provider-agnostic SMTP wiring. Defaults to Resend
-# (smtp.resend.com) because that's what production runs, but every
-# value is overridable via env vars so a future provider swap is a
-# config change rather than a code change.
+# Email delivery via Resend's HTTPS API.
 #
-# Required env vars in production:
-#   SMTP_PASSWORD  — for Resend, the API key value
-#                    (or set RESEND_API_KEY and we'll pick it up)
+# Originally configured for SMTP, but Railway blocks outbound SMTP
+# entirely (both implicit-TLS on 465 and STARTTLS on 587 time out at
+# the TCP-connect stage). Switching to Resend's REST API over HTTPS
+# bypasses the block — Railway doesn't restrict outbound HTTPS.
 #
-# Optional (defaults match Resend's STARTTLS endpoint):
-#   SMTP_HOST  — default smtp.resend.com
-#   SMTP_PORT  — default 587 (STARTTLS); 465 / 2465 for implicit TLS
-#   SMTP_USER  — default 'resend'
+# The `resend` gem registers a `:resend` ActionMailer delivery
+# method that takes a Mail::Message and POSTs it to
+# https://api.resend.com/emails. Same `Mailer#action.deliver_now`
+# call site — only the wire format changes.
 #
-# TLS strategy is auto-picked by port: 465 / 2465 use implicit TLS
-# (TLS handshake on connect), every other port uses STARTTLS (plain
-# socket then upgrade). Default is 587 because some cloud providers
-# (Railway included) only allow outbound STARTTLS, not implicit TLS.
+# Required env var in production:
+#   RESEND_API_KEY  — API key from the Resend dashboard
+#
+# The test environment keeps its `:test` delivery method (set in
+# config/environments/test.rb), so specs don't hit the network.
 class ApplicationMailer < ActionMailer::Base
-  # From-address domain (testhub.mesastar.org) is the one we verify
-  # with the email provider. Any future mailer overrides this via
-  # its own `default from:`.
+  # From-address domain (testhub.mesastar.org) is the one verified
+  # in Resend. Any future mailer overrides this via its own
+  # `default from:`.
   default from: 'digest@testhub.mesastar.org'
   layout 'mailer'
 end
 
-smtp_port = ENV.fetch('SMTP_PORT', '587').to_i
-tls_options =
-  if [465, 2465].include?(smtp_port)
-    { tls: true }
-  else
-    { enable_starttls_auto: true }
-  end
-
-ApplicationMailer.smtp_settings = {
-  address:        ENV.fetch('SMTP_HOST', 'smtp.resend.com'),
-  port:           smtp_port,
-  user_name:      ENV.fetch('SMTP_USER', 'resend'),
-  password:       ENV['SMTP_PASSWORD'] || ENV['RESEND_API_KEY'],
-  domain:         'testhub.mesastar.org',
-  authentication: :plain
-}.merge(tls_options)
-ApplicationMailer.delivery_method = :smtp
+if Rails.env.production?
+  ApplicationMailer.delivery_method = :resend
+  ApplicationMailer.resend_settings = { api_key: ENV['RESEND_API_KEY'] }
+end

--- a/docs/morning-mailer.md
+++ b/docs/morning-mailer.md
@@ -63,33 +63,34 @@ Metrics checked: `runtime_seconds` (rn), `re_time` (re),
 Tweak the thresholds in `MorningReport` if the signal-to-noise is
 off for your use case.
 
-## Email provider — Resend
+## Email provider — Resend (HTTPS API, not SMTP)
 
-SMTP wiring in [`app/mailers/application_mailer.rb`](../app/mailers/application_mailer.rb)
-is provider-agnostic: it defaults to Resend's STARTTLS SMTP endpoint
-(`smtp.resend.com:587`, username `resend`) but every value is
-overridable via env vars.  Swapping to a different provider is a
-config change, not a code change.
+Delivery goes through Resend's REST API over HTTPS via the
+[`resend`](https://github.com/resend/resend-ruby) gem's
+ActionMailer adapter, **not** SMTP.  Railway blocks outbound SMTP
+on every port we tried (465 / 587 both hit `Net::OpenTimeout` at
+the TCP-connect stage); HTTPS isn't blocked.  Same
+`MorningMailer.daily.deliver_now` call site, different wire format.
 
-The TLS strategy is auto-picked by port: 465 / 2465 use implicit
-TLS (handshake on connect); every other port (587, 2587, 25, …)
-uses STARTTLS.  Default is 587 because some cloud hosts —
-Railway among them — block outbound implicit-TLS SMTP but allow
-STARTTLS.
+If you ever move off Railway to a host that *does* allow outbound
+SMTP, swapping back is reverting the
+[`app/mailers/application_mailer.rb`](../app/mailers/application_mailer.rb)
+change to set `delivery_method = :smtp` with `smtp_settings`
+pointing at the provider.
 
 ### Required env vars (cron service)
 
-| Var | Default | Purpose |
-|---|---|---|
-| `SMTP_PASSWORD` *or* `RESEND_API_KEY` | — | API key from Resend's dashboard. The code reads `SMTP_PASSWORD` first, then falls back to `RESEND_API_KEY`, so either name works. |
-| `SMTP_HOST` | `smtp.resend.com` | SMTP endpoint hostname. |
-| `SMTP_PORT` | `587` | 587 (STARTTLS) or 2587 (STARTTLS alt) work on Railway. 465 / 2465 (implicit TLS) may be blocked; only use those if you've confirmed outbound 465 works for your host. |
-| `SMTP_USER` | `resend` | Resend uses the literal username `resend` for every account; only the password (API key) identifies you. |
-| `DATABASE_URL` | — | Reference the Railway Postgres service: `${{Postgres.DATABASE_URL}}`. |
-| `SECRET_KEY_BASE` | — | Required for Rails to boot. Reference the web service's: `${{MESATestHub.SECRET_KEY_BASE}}`. |
-| `GIT_TOKEN` | — | Optional but recommended — without it, the digest shows "couldn't check" for the release-blocker line. Reference the web service's: `${{MESATestHub.GIT_TOKEN}}`. |
-| `RAILS_ENV` | — | Set to `production`. |
-| `TZ` | UTC | Set to `America/New_York` so `Time.now` reads Eastern inside the rake task's "is it 8 AM yet?" guard. Note: the Railway cron *scheduler* itself always evaluates in UTC — see the cron section below. |
+| Var | Purpose |
+|---|---|
+| `RESEND_API_KEY` | API key from Resend's dashboard. |
+| `DATABASE_URL` | Reference the Railway Postgres service: `${{Postgres.DATABASE_URL}}`. |
+| `SECRET_KEY_BASE` | Required for Rails to boot. Reference the web service's: `${{MESATestHub.SECRET_KEY_BASE}}`. |
+| `GIT_TOKEN` | Optional but recommended — without it, the digest shows "couldn't check" for the release-blocker line. Reference the web service's: `${{MESATestHub.GIT_TOKEN}}`. |
+| `RAILS_ENV` | Set to `production` (gates the `:resend` delivery method — see [`application_mailer.rb`](../app/mailers/application_mailer.rb)). |
+| `TZ` | Set to `America/New_York` so `Time.now` reads Eastern inside the rake task's "is it 8 AM yet?" guard. Note: the Railway cron *scheduler* itself always evaluates in UTC — see the cron section below. |
+
+Old `SMTP_*` env vars from the SMTP era can be removed; they're
+no longer read.
 
 ### Domain verification in Resend
 


### PR DESCRIPTION
## Summary

Railway blocks outbound SMTP on every port — both 465 (implicit TLS, [#85](https://github.com/MESAHub/MESATestHub/pull/85)) and 587 (STARTTLS, [#86](https://github.com/MESAHub/MESATestHub/pull/86)) hit `Net::OpenTimeout` at the TCP-connect stage on Resend's `smtp.resend.com`.  This isn't a Resend issue or a misconfiguration; Railway permits outbound HTTPS but not SMTP.

Switching to Resend's REST API over HTTPS bypasses the block.

### Changes

- **`Gemfile`** — add `gem 'resend'` (v1.3.0).
- **`app/mailers/application_mailer.rb`** — replace the SMTP wiring with `delivery_method = :resend` and `resend_settings = { api_key: ENV['RESEND_API_KEY'] }`. Gated on `Rails.env.production?` so the test env keeps `:test` delivery.
- **`docs/morning-mailer.md`** — collapse the SMTP env var table to just `RESEND_API_KEY`; note the SMTP-was-blocked rationale.

The call site (`MorningMailer.daily.deliver_now`) doesn't change — the `resend` gem's ActionMailer adapter converts the `Mail::Message` into an HTTPS POST to `api.resend.com/emails`.

## Test plan

- [x] `bundle exec rspec` — 304 examples, 0 failures (specs use `:test` delivery method, unaffected by the production-only change).
- [ ] After deploy: clean up the cron service's variables — remove any `SMTP_*` vars (no longer read). Trigger a manual fire with `FORCE=1 bundle exec rake morning_mailer:daily` from the Railway dashboard.
- [ ] Verify the message lands in mesa-developers and the Slack inbound, and that Resend's dashboard shows the API request as 200/delivered.