### PR TITLE
Set Resend.api_key globally (gem ignores resend_settings)

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,29 +1,33 @@
 # Email delivery via Resend's HTTPS API.
 #
 # Originally configured for SMTP, but Railway blocks outbound SMTP
-# entirely (both implicit-TLS on 465 and STARTTLS on 587 time out at
-# the TCP-connect stage). Switching to Resend's REST API over HTTPS
-# bypasses the block — Railway doesn't restrict outbound HTTPS.
+# entirely (both 465 and 587 time out at TCP-connect).  Resend's
+# REST API over HTTPS bypasses the block.
 #
 # The `resend` gem registers a `:resend` ActionMailer delivery
 # method that takes a Mail::Message and POSTs it to
-# https://api.resend.com/emails. Same `Mailer#action.deliver_now`
-# call site — only the wire format changes.
+# https://api.resend.com/emails.  Quirk in resend 1.3.0: the gem
+# checks the *global* `Resend.api_key` on every delivery, ignoring
+# the per-mailer `resend_settings[:api_key]` that Rails passes in.
+# So we set the global directly — see
+# `gems/resend-1.3.0/lib/resend/mailer.rb:25`.
 #
 # Required env var in production:
 #   RESEND_API_KEY  — API key from the Resend dashboard
 #
 # The test environment keeps its `:test` delivery method (set in
 # config/environments/test.rb), so specs don't hit the network.
+require "resend"
+
 class ApplicationMailer < ActionMailer::Base
   # From-address domain (testhub.mesastar.org) is the one verified
-  # in Resend. Any future mailer overrides this via its own
+  # in Resend.  Any future mailer overrides this via its own
   # `default from:`.
   default from: 'digest@testhub.mesastar.org'
   layout 'mailer'
 end
 
 if Rails.env.production?
+  Resend.api_key = ENV['RESEND_API_KEY']
   ApplicationMailer.delivery_method = :resend
-  ApplicationMailer.resend_settings = { api_key: ENV['RESEND_API_KEY'] }
 end


### PR DESCRIPTION
## Summary

The first 8 AM ET cron fire on Railway after [#87](https://github.com/MESAHub/MESATestHub/pull/87) got past the SMTP block (good!) but hit `Resend::Error: Make sure your API Key is set` from `gems/resend-1.3.0/lib/resend/mailer.rb:25`.

Looking at the gem source:

```ruby
def initialize(config)
  @config = config
  raise Resend::Error.new("Make sure your API Key is set", @config) unless Resend.api_key
  ...
end
```

The gem stores the `config` we pass via `ApplicationMailer.resend_settings = { api_key: ... }` but only checks the global `Resend.api_key` for the presence check. So my settings hash was a no-op.

Fix: `require 'resend'` and set `Resend.api_key = ENV['RESEND_API_KEY']` directly in production. Drop the `resend_settings` line — unused.

## Test plan

- [x] `bundle exec rspec` — 304 examples, 0 failures (test env stays on `:test` delivery).
- [ ] After deploy: next 8 AM ET cron fire should deliver successfully (or surface a different, more specific Resend API error if there's still something wrong).