### PR TITLE
Add branch: filter and full-SHA support to test_instances search

### DIFF
--- a/app/models/test_instance.rb
+++ b/app/models/test_instance.rb
@@ -789,8 +789,12 @@ class TestInstance < ApplicationRecord
   end
 
 
-  # overridden to get user names, computer names, and other details
-  def as_json(options)
+  # overridden to get user names, computer names, and other details.
+  # `options` is part of the Rails as_json contract but is not used
+  # here; the default makes the method callable from paths that
+  # don't pass anything (which broke the JSON search endpoint as
+  # soon as it had to serialize a non-empty result set).
+  def as_json(options = nil)
     {
       test_case: test_case.name,
       commit: commit.to_json,

--- a/app/models/test_instance.rb
+++ b/app/models/test_instance.rb
@@ -402,8 +402,12 @@ class TestInstance < ApplicationRecord
     # building up the search query from many pre-defined searchable options.
     options = [
       SearchOption.new('test_case', TestCase, :name),
+      # Match on short_sha (7 hex chars). Truncate the user input to
+      # the first 7 chars so a pasted full 40-char SHA still resolves,
+      # and downcase so an uppercase paste from a terminal still hits
+      # the lowercase column.
       SearchOption.new('commit', Commit, :short_sha) do |sha|
-        sha[(0..7)]
+        sha.to_s.downcase.strip[0, 7]
       end,
       SearchOption.new('commit_datetime', Commit, :commit_time, true) do |datetime|
         Date.parse(datetime)
@@ -477,6 +481,15 @@ class TestInstance < ApplicationRecord
     #   query_hash[m1[:key]] = m1[:value]
     # end
     query_hash = split_query(query_text)
+
+    # `branch:` lives outside the SearchOption mechanism because
+    # branches relate to test instances transitively through commits
+    # and BranchMembership — there's no `branch_id` on TestInstance
+    # that the generic SearchOption.query_piece can target. Pop it
+    # out *before* the unknown-key check so it isn't flagged as
+    # unrecognized, and apply the filter after the SearchOption loop.
+    branch_value = query_hash.delete('branch')
+
     query_hash.keys.each do |key|
       unless option_names.include?(key)
         failed_requirements << key
@@ -498,6 +511,26 @@ class TestInstance < ApplicationRecord
         # commonly a malformed date/datetime). Treat it like an unknown
         # key — drop it from the query and report it back to the view.
         failed_requirements << "#{key} (#{value.inspect})"
+      end
+    end
+
+    # Apply `branch:` here so it composes with whatever the
+    # SearchOption loop produced. Comma-separated branch names mean
+    # OR. Branch names that don't resolve to a Branch row get
+    # reported back so the form can warn the user; if NONE of the
+    # requested branches exist, scope the result set to none rather
+    # than silently dropping the filter and showing every instance.
+    if branch_value
+      branch_names = branch_value.split(',').map(&:strip).reject(&:empty?)
+      branches     = Branch.where(name: branch_names)
+      unknown      = branch_names - branches.pluck(:name)
+      failed_requirements << "branch (#{unknown.join(', ')})" if unknown.any?
+      if branches.any?
+        commit_ids = BranchMembership.where(branch_id: branches.select(:id))
+                                     .distinct.pluck(:commit_id)
+        res = res.where(commit_id: commit_ids)
+      else
+        res = res.none
       end
     end
 

--- a/app/views/test_instances/search.html.haml
+++ b/app/views/test_instances/search.html.haml
@@ -64,6 +64,12 @@
             Comma-separate values for OR, or use a dash for ranges:
           %p.mt-2
             %code.font-mono.text-fg{ class: "rounded-md bg-bg-muted px-2 py-0.5 text-[12px]" } commit_datetime: 2024-01-01-2024-06-30; test_case: wd2, 1M_thermohaline
+          %p.mt-3.text-fg-muted
+            Want failing tests on
+            %code.font-mono.text-fg{ class: "rounded-md bg-bg-muted px-1.5 py-0.5 text-[11px]" } main
+            from a specific computer in the last few days? Combine
+            %code.font-mono.text-fg{ class: "rounded-md bg-bg-muted px-1.5 py-0.5 text-[11px]" } branch:
+            with the existing filters.
 
       -# Available fields, two columns.
       %div
@@ -71,7 +77,8 @@
         .grid.gap-x-8.gap-y-1{ class: "grid-cols-1 md:grid-cols-2 text-[13px]" }
           %dl.space-y-2
             = render "field_row", field: "test_case", desc: "Name of a valid test case."
-            = render "field_row", field: "commit", desc: "Short SHA of a commit (first 7+ characters)."
+            = render "field_row", field: "commit", desc: "Commit SHA — paste the short (7-char) or full 40-char hash. Case-insensitive."
+            = render "field_row", field: "branch", desc: "Branch name (exact). Limits to instances whose commit lives on the named branch. Comma-separate for OR."
             = render "field_row", field: "commit_datetime", desc: "Commit datetime — YYYY-MM-DD. Range supported (e.g. 2024-01-01-2024-06-30)."
             = render "field_row", field: "passed", desc: %q{"t" / "true" / "f" / "false" — match passing or failing instances.}
             = render "field_row", field: "computer", desc: "Name of a computer."

--- a/spec/models/test_instance_query_spec.rb
+++ b/spec/models/test_instance_query_spec.rb
@@ -88,6 +88,85 @@ RSpec.describe TestInstance, '.query', type: :model do
       expect(failures).to be_empty
       expect(relation.to_a).to contain_exactly(mid_instance)
     end
+
+    it 'matches a commit by full 40-char SHA' do
+      relation, failures = TestInstance.query("commit: #{mid_commit.sha}")
+      expect(failures).to be_empty
+      expect(relation.to_a).to contain_exactly(mid_instance)
+    end
+
+    it 'is case-insensitive on commit SHA input' do
+      relation, failures = TestInstance.query(
+        "commit: #{mid_commit.short_sha.upcase}"
+      )
+      expect(failures).to be_empty
+      expect(relation.to_a).to contain_exactly(mid_instance)
+    end
+  end
+
+  describe 'branch filtering' do
+    let(:test_case) { create(:test_case) }
+    let(:computer)  { create(:computer) }
+    let(:main_branch)    { create(:branch, name: 'main') }
+    let(:feature_branch) { create(:branch, name: 'feature-x') }
+    let(:main_commit)    { create(:commit) }
+    let(:feature_commit) { create(:commit) }
+    let(:shared_commit)  { create(:commit) }
+
+    before do
+      BranchMembership.create!(branch: main_branch,    commit: main_commit)
+      BranchMembership.create!(branch: feature_branch, commit: feature_commit)
+      BranchMembership.create!(branch: main_branch,    commit: shared_commit)
+      BranchMembership.create!(branch: feature_branch, commit: shared_commit)
+    end
+
+    let!(:main_instance) do
+      make_instance(commit: main_commit, computer: computer, test_case: test_case)
+    end
+    let!(:feature_instance) do
+      make_instance(commit: feature_commit, computer: computer, test_case: test_case)
+    end
+    let!(:shared_instance) do
+      make_instance(commit: shared_commit, computer: computer, test_case: test_case)
+    end
+
+    it 'narrows to instances whose commit is on the requested branch' do
+      relation, failures = TestInstance.query('branch: main')
+      expect(failures).to be_empty
+      expect(relation.to_a).to contain_exactly(main_instance, shared_instance)
+    end
+
+    it 'unions instances across comma-separated branches' do
+      relation, failures = TestInstance.query('branch: main, feature-x')
+      expect(failures).to be_empty
+      expect(relation.to_a).to contain_exactly(
+        main_instance, feature_instance, shared_instance
+      )
+    end
+
+    it 'composes with other filters via AND' do
+      other_test_case = create(:test_case)
+      other_instance  = make_instance(commit: main_commit, computer: computer,
+                                       test_case: other_test_case)
+      relation, failures = TestInstance.query(
+        "branch: main; test_case: #{test_case.name}"
+      )
+      expect(failures).to be_empty
+      expect(relation.to_a).to contain_exactly(main_instance, shared_instance)
+      expect(relation.to_a).not_to include(other_instance)
+    end
+
+    it 'returns no instances and reports the failure for an unknown branch' do
+      relation, failures = TestInstance.query('branch: no-such-branch')
+      expect(relation.to_a).to be_empty
+      expect(failures).to include(a_string_starting_with('branch (no-such-branch'))
+    end
+
+    it 'partial-match: keeps known branches and flags unknown ones' do
+      relation, failures = TestInstance.query('branch: main, no-such-branch')
+      expect(relation.to_a).to contain_exactly(main_instance, shared_instance)
+      expect(failures).to include(a_string_starting_with('branch (no-such-branch'))
+    end
   end
 
   describe 'rn_runtime / re_runtime fields' do

--- a/spec/requests/test_instances_search_api_spec.rb
+++ b/spec/requests/test_instances_search_api_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+# JSON-API surface for `test_instances#search`. The query parser
+# itself is covered exhaustively by `spec/models/test_instance_query_spec.rb`;
+# this file's job is to lock in that both the HTML and JSON formats
+# pass user input through the same `TestInstance.query` pipeline,
+# and that the JSON envelope (`results` + `failures`) carries the
+# new `branch:` filter and the full-SHA `commit:` fix end-to-end.
+#
+# These tests use a browser-style session (POST /sessions then
+# follow-up GETs reuse the cookie). The controller advertises a
+# stateless email/password fallback inside `authenticated?`, but
+# the global `authorize_user` before_action redirects unauthenticated
+# callers before the action body ever runs — so that fallback is
+# effectively dead code. Reaching the JSON endpoint without a
+# session is a separate concern; this spec exercises the path that
+# does work.
+RSpec.describe 'GET /test_instances/search.json', type: :request do
+  let(:user) do
+    create(:user, password: 'pw-12345678', password_confirmation: 'pw-12345678')
+  end
+  let(:test_case)      { create(:test_case) }
+  let(:computer)       { create(:computer, user: user) }
+  let(:main_branch)    { create(:branch, name: 'main') }
+  let(:feature_branch) { create(:branch, name: 'feature-x') }
+  let(:main_commit)    { create(:commit) }
+  let(:feature_commit) { create(:commit) }
+
+  before do
+    BranchMembership.create!(branch: main_branch,    commit: main_commit)
+    BranchMembership.create!(branch: feature_branch, commit: feature_commit)
+    post '/sessions', params: { email: user.email, password: 'pw-12345678' }
+  end
+
+  def make_instance(commit:)
+    submission = create(:submission, commit: commit, computer: computer)
+    create(:test_instance, commit: commit, computer: computer,
+                           test_case: test_case, submission: submission)
+  end
+
+  let!(:main_instance)    { make_instance(commit: main_commit) }
+  let!(:feature_instance) { make_instance(commit: feature_commit) }
+
+  it 'filters by branch through the JSON endpoint' do
+    get '/test_instances/search.json', params: { query_text: 'branch: main' }
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['failures']).to be_empty
+    expect(body['results'].size).to eq(1)
+  end
+
+  it 'reports unknown branches in the failures array without raising' do
+    get '/test_instances/search.json',
+        params: { query_text: 'branch: no-such-branch' }
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['results']).to be_empty
+    expect(body['failures']).to include(a_string_starting_with('branch (no-such-branch'))
+  end
+
+  it 'resolves a full 40-char SHA through the JSON endpoint' do
+    get '/test_instances/search.json',
+        params: { query_text: "commit: #{main_commit.sha}" }
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['failures']).to be_empty
+    expect(body['results'].size).to eq(1)
+  end
+
+  it 'composes branch with the rest of the query language' do
+    get '/test_instances/search.json',
+        params: { query_text: "branch: main; computer: #{computer.name}" }
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['failures']).to be_empty
+    expect(body['results'].size).to eq(1)
+  end
+
+  describe 'GET /test_instances/search_count.json' do
+    it 'returns the count for a branch query' do
+      get '/test_instances/search_count.json',
+          params: { query_text: 'branch: main' }
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body['failures']).to be_empty
+      expect(body['count']).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `branch:` as a new top-level key in the test_instances search query language. Filters to instances whose commit lives on the named branch; comma-separated for OR; composes with the rest of the query via AND; unknown branches are reported back inline.
- Fixes `commit:` to accept a full 40-character SHA. The old preprocessor sliced the first 8 chars (`sha[(0..7)]` is inclusive) and compared against the 7-char short_sha column — full SHAs always missed silently. Also makes the comparison case-insensitive.
- Updates the form's syntax reference and the field list to reflect both changes.

Closes [#37](https://github.com/MESAHub/MESATestHub/issues/37) — the workflow the issue described ("paste a SHA, find its instances") now works directly, and the same form answers the broader question of "show me failing tests on branch X from computer Y in the last N days."

## Test plan
- [x] `bundle exec rspec spec/models/test_instance_query_spec.rb` — 7 new examples covering `branch:` (single, comma-OR, composed-with-AND, unknown branch, partial-match) and the SHA bug fix (full 40-char, case-insensitive). 40 examples pass.
- [x] Full suite green (`bundle exec rspec` — 311 examples, 0 failures).
- [x] Manually verified against dev DB (live snapshot of production):
  - `branch: main; passed: false` → 6317 failing instances on main.
  - `branch: main; computer: ccalin046; date: 2026-01-01-2026-05-26` → 5 failing radiative_levitation / starspots instances from ccalin046 in early 2026.
  - `branch: no-such-branch` → 0 results + "Invalid search parameters: branch (no-such-branch)" inline warning.
  - `commit: 0671b8f16bf6080e75bb8edea94fcf7cc80368d6` → 1 instance (custom_colors on VVEEGGAA). Previously returned nothing.