### PR TITLE
Restore JSON auth for test_instances#search (mesa_test API path)

### DIFF
--- a/app/controllers/test_instances_controller.rb
+++ b/app/controllers/test_instances_controller.rb
@@ -1,6 +1,22 @@
 class TestInstancesController < ApplicationController
   layout "modern", only: [:search]
 
+  # The JSON variants of search / search_count are the API path that
+  # mesa_test (and other CLI clients) hit to read past test
+  # instances. They authenticate per-request via `email` + `password`
+  # params inside the `authenticated?` helper — there's no browser
+  # session involved. The global `authorize_user` before_action
+  # added in commit b8542bc (Sep 2025) didn't exempt this controller,
+  # which silently broke every external client.
+  #
+  # Skip the global filter only for the JSON paths; the HTML search
+  # page stays behind the login wall (intentional from b8542bc — the
+  # goal there was to reduce anonymous browse traffic). The action
+  # body still enforces auth via `authenticated?`. `search_count`
+  # is JSON-only, so unconditional skip is fine there.
+  skip_before_action :authorize_user, only: [:search, :search_count]
+  before_action :gate_html_search_to_authenticated_users, only: [:search]
+
   # Cross-cuts every test run on every computer for every commit
   # using a single key-value query language. See
   # `TestInstance.query` for the backend.
@@ -55,6 +71,20 @@ class TestInstancesController < ApplicationController
   end
 
   private
+
+  # The HTML variant of #search should remain behind the same login
+  # wall the rest of the browser views are. Restoring the global
+  # before_action with a controller-level skip is the wrong shape
+  # here because the conditional-`if:` form doesn't play well with
+  # format detection (the lambda doesn't appear to be consulted
+  # consistently on `skip_before_action` in Rails 8). Instead, skip
+  # the global gate unconditionally and re-impose it on the HTML
+  # format only.
+  def gate_html_search_to_authenticated_users
+    return if request.format.json?
+    return if current_user
+    redirect_to login_url, alert: 'Most pages are restricted to logged-in users. New accounts can only be created by an admin.'
+  end
 
   # Authenticates the JSON-API path. Hits the existing session
   # first (so a logged-in browser making a fetch() against the

--- a/spec/requests/test_instances_search_auth_spec.rb
+++ b/spec/requests/test_instances_search_auth_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+# Auth boundary for test_instances#search.
+#
+# Background: in 2019 (commit 6112b7f) the JSON variant of this
+# action was given a stateless `email` + `password` auth path so
+# CLI clients like `mesa_test` could pull past test instances
+# without a browser session. In September 2025 (commit b8542bc) a
+# global `authorize_user` before_action went into ApplicationController
+# to reduce anonymous browse traffic, but the curated skip list
+# omitted this controller — silently 302-ing every external API
+# caller to /login.
+#
+# This spec locks in the corrected behaviour:
+#   - HTML format stays behind the login wall (preserves b8542bc's intent)
+#   - JSON format bypasses the global filter and authenticates per
+#     request via the action's own `authenticated?` helper
+#   - The JSON-only `search_count` always authenticates per request
+RSpec.describe 'Auth boundary for /test_instances/search', type: :request do
+  let(:password) { 'pw-12345678' }
+  let(:user) do
+    create(:user, password: password, password_confirmation: password)
+  end
+
+  describe 'HTML format (browser path)' do
+    it 'redirects anonymous users to the login page' do
+      get '/test_instances/search'
+      expect(response).to redirect_to(login_path)
+    end
+
+    it 'lets authenticated users render the page' do
+      post '/sessions', params: { email: user.email, password: password }
+      get '/test_instances/search'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'JSON format (mesa_test / CLI path)' do
+    it 'accepts a stateless email + password and returns results, not a 302' do
+      get '/test_instances/search.json',
+          params: { email: user.email, password: password, query_text: 'passed: true' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with('application/json')
+      body = JSON.parse(response.body)
+      expect(body).to include('results', 'failures')
+    end
+
+    it 'returns a JSON error (not a redirect) when no credentials are given' do
+      get '/test_instances/search.json', params: { query_text: 'passed: true' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.content_type).to start_with('application/json')
+      expect(JSON.parse(response.body)).to include('error')
+    end
+
+    it 'returns a JSON error when the email/password are wrong' do
+      get '/test_instances/search.json',
+          params: { email: user.email, password: 'wrong-password',
+                    query_text: 'passed: true' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)).to include('error')
+    end
+
+    it 'also accepts a browser session (no params needed)' do
+      post '/sessions', params: { email: user.email, password: password }
+      get '/test_instances/search.json', params: { query_text: 'passed: true' }
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body).to include('results', 'failures')
+    end
+  end
+
+  describe 'JSON format (search_count)' do
+    it 'accepts a stateless email + password' do
+      get '/test_instances/search_count.json',
+          params: { email: user.email, password: password, query_text: 'passed: true' }
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body).to include('count', 'failures')
+    end
+
+    it 'returns a JSON error (not a redirect) when unauthenticated' do
+      get '/test_instances/search_count.json', params: { query_text: 'passed: true' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)).to include('error')
+    end
+  end
+end


### PR DESCRIPTION
## What broke

Commit [b8542bc](https://github.com/MESAHub/MESATestHub/commit/b8542bc) (Sep 15, 2025) — "Restrict most pages to logged-in users to reduce traffic" — added a global `authorize_user` before_action to `ApplicationController` with a curated list of `skip_before_action` exemptions. The list covered login/sessions, GitHub webhooks, the submissions API, and computer auth, but missed `TestInstancesController#search` and `#search_count`, which had their own action-level email/password auth (added by [6112b7f](https://github.com/MESAHub/MESATestHub/commit/6112b7f) back in 2019).

The result: since September 2025, every JSON call to `/test_instances/search.json` and `/test_instances/search_count.json` from `mesa_test` (or any other CLI client) has been silently 302'd to `/login` instead of authenticating with the supplied email/password and returning results. The action-level `authenticated?` helper became dead code.

## What this PR does

- Skip the global `authorize_user` for both JSON endpoints on `TestInstancesController`. The action body still enforces auth via the existing `authenticated?` helper (session-first, falling back to `email` + `password` params).
- Re-impose the HTML login gate via a tiny `gate_html_search_to_authenticated_users` before_action, so b8542bc's intent ("reduce anonymous browse traffic") is preserved for the browser path.
- Why not `skip_before_action :authorize_user, only: [:search], if: -> { request.format.json? }`? Tried it — the lambda doesn't appear to be consulted consistently on `skip_before_action` in Rails 8 (the HTML path bypassed `authorize_user` even with `if: format.json?`). The explicit method-based gate is easier to reason about anyway.

## Test plan
- [x] New `spec/requests/test_instances_search_auth_spec.rb` — 8 examples pinning every cell of the auth matrix:
  - HTML anonymous → 302 to `/login`
  - HTML authenticated → 200
  - JSON anonymous (no creds) → 422 JSON error (not 302)
  - JSON wrong creds → 422 JSON error
  - JSON valid email/password → 200 results
  - JSON via browser session → 200 results
  - `search_count.json` same shape (anonymous → 422 error; with creds → 200 count)
- [x] Full suite green: 312 examples, 0 failures.

## Severity

External clients have been broken for ~8 months. This should merge ahead of #90 (the branch-filter + SHA-fix work, which sits cleanly on top of this fix).