### PR TITLE
Show test results from compile-less singleton submissions

### DIFF
--- a/app/helpers/test_instances_helper.rb
+++ b/app/helpers/test_instances_helper.rb
@@ -1,2 +1,17 @@
 module TestInstancesHelper
+  # Pick the branch slug to use in a commit / test-case URL for a
+  # given commit. Prefers `main` when the commit lives there,
+  # otherwise picks the first containing branch alphabetically.
+  # Falls back to `"main"` for the edge case of a commit with no
+  # branch memberships (the controller's branch-fallback will catch
+  # the mismatch and redirect to a real branch).
+  #
+  # Expects `commit.branches` to already be eager-loaded — the
+  # search query does this via TestInstance.query's includes.
+  def best_branch_name_for(commit)
+    branches = commit.branches.to_a
+    return "main" if branches.empty?
+    return "main" if branches.any? { |b| b.name == "main" }
+    branches.min_by(&:name).name
+  end
 end

--- a/app/models/concerns/commit_state.rb
+++ b/app/models/concerns/commit_state.rb
@@ -479,10 +479,22 @@ module CommitState
     @_build_stati_by_computer ||= begin
       rows = submissions.pluck(:computer_id, :compiled)
       grouped = rows.group_by(&:first)
+      # Test-by-test clients submit each result as a singleton submission
+      # without an `entire`/`empty` flag, so the submissions controller
+      # never records a `compiled` value (see SubmissionsController#create).
+      # The aggregate used to drop those computers entirely, hiding their
+      # results from the per-computer summary and the matrix. Submitting a
+      # test result implies a successful build, so any computer with test
+      # instances on this commit is implicitly built when no explicit
+      # signal exists.
+      implicit_built = test_instances.distinct.pluck(:computer_id).to_set
       grouped.each_with_object({}) do |(computer_id, computer_rows), out|
         flags = computer_rows.map(&:last).compact
-        next if flags.empty?
-        out[computer_id] = flags.any? { |ok| ok }
+        if flags.empty?
+          out[computer_id] = true if implicit_built.include?(computer_id)
+        else
+          out[computer_id] = flags.any? { |ok| ok }
+        end
       end
     end
   end

--- a/app/models/test_instance.rb
+++ b/app/models/test_instance.rb
@@ -502,7 +502,7 @@ class TestInstance < ApplicationRecord
     end
 
     res = res.where.not(commit_id: nil)
-    return [res.includes(:test_case, :test_case_commit, :commit, computer: :user).
+    return [res.includes(:test_case, :test_case_commit, computer: :user, commit: :branches).
       order('commits.commit_time DESC, test_instances.created_at DESC'), failed_requirements]
   end
 

--- a/app/views/test_instances/search.html.haml
+++ b/app/views/test_instances/search.html.haml
@@ -127,14 +127,15 @@
           %tbody
             - @test_instances.each do |ti|
               - next unless ti.commit
+              - branch_slug = best_branch_name_for(ti.commit)
               %tr.border-b.border-border-subtle.align-middle.hover:bg-bg-subtle{ class: "[&>td]:py-2" }
                 %td.px-3.font-mono.whitespace-nowrap{ class: "text-[12px]" }
                   = link_to ti.commit.short_sha,
-                           commit_path(branch: "main", sha: ti.commit.short_sha),
+                           commit_path(branch: branch_slug, sha: ti.commit.short_sha),
                            class: "text-brand font-semibold no-underline hover:underline"
                 %td.px-3.font-mono.whitespace-nowrap{ class: "text-[12px]" }
                   = link_to ti.test_case.name,
-                           test_case_commit_path(branch: "main", module: ti.test_case.module, test_case: ti.test_case.name, sha: ti.commit.short_sha),
+                           test_case_commit_path(branch: branch_slug, module: ti.test_case.module, test_case: ti.test_case.name, sha: ti.commit.short_sha),
                            class: "text-fg-muted hover:text-brand no-underline"
                 %td.px-3.whitespace-nowrap{ class: "text-[12px]" }
                   - if ti.passed

--- a/spec/models/commit_state_spec.rb
+++ b/spec/models/commit_state_spec.rb
@@ -99,6 +99,23 @@ RSpec.describe 'commit state aggregation' do
       submit(computer: frontera, compiled: true)
       expect(commit.reload.build_status).to eq(:all_ok)
     end
+
+    it 'treats a singleton submission with no compile flag as built when it carries a test instance' do
+      # Test-by-test clients submit each result on its own with no
+      # `entire`/`empty` flag, so the submissions controller leaves
+      # `compiled` nil. The presence of a test instance implies the
+      # build succeeded.
+      submit(computer: rusty, compiled: nil)
+      instance(test_case: test_case_a, computer: rusty, passed: true)
+      expect(commit.reload.build_status).to eq(:all_ok)
+    end
+
+    it 'still returns :unknown for a compile-less submission with no test instances' do
+      # An empty singleton submission carries no signal at all — don't
+      # invent a build status for it.
+      submit(computer: rusty, compiled: nil)
+      expect(commit.reload.build_status).to eq(:unknown)
+    end
   end
 
   describe '#tests_status' do
@@ -311,6 +328,20 @@ RSpec.describe 'commit state aggregation' do
       expect(row[:counts][:pass]).to eq(1)
       expect(row[:counts][:fail]).to eq(1)
       expect(row[:counts][:fpe]).to eq(1)
+    end
+
+    it 'includes computers whose only submissions carry no compile flag but have results' do
+      # Regression: singleton submissions (compiled=nil) used to drop
+      # the computer out of the per-computer summary entirely, which
+      # hid the matrix column even though the test_instances were
+      # safely in the database.
+      submit(computer: popeye, compiled: nil)
+      instance(test_case: test_case_a, computer: popeye, passed: true)
+
+      row = commit.reload.per_computer_summary.find { |r| r[:computer].name == 'popeye' }
+      expect(row).not_to be_nil
+      expect(row[:state]).to eq(:all_pass)
+      expect(row[:counts][:pass]).to eq(1)
     end
   end
 


### PR DESCRIPTION
## Summary

- Commit summary matrix now includes computers whose only submissions were singleton (test-by-test) submissions with `compiled = nil`. Running a test implies a successful build, so any computer with test instances on a commit is treated as implicitly built when no explicit compile signal exists.
- Test-instance search results now link to a branch that actually contains each commit, instead of hardcoding `branch: "main"` everywhere.

## Background

User-reported regression: searching `computer:VVEEGGAA` returned 112 passing test instances across 4 commits, but clicking through to those commits, three of them showed no VVEEGGAA column at all. Niall's client submits results test-by-test; [SubmissionsController#create](app/controllers/submissions_controller.rb#L22-L31) only records `compiled` on `entire` / `empty` submissions, so every VVEEGGAA submission landed with `compiled = nil`. `_build_stati_by_computer` compact-ed those nils away and skipped the computer, so `per_computer_summary` produced no row and the matrix view rendered no column.

The data was always intact — the test_case_commit page rendered VVEEGGAA's row fine — but the commit overview made it invisible.

While in there, the search results page hardcoded `branch: "main"` in every commit/test-case link. For commits not on `main` the URL resolved (because `main` exists as a branch) but rendered the commit in main's context. Now picks a containing branch.

## Changes

- `app/models/concerns/commit_state.rb` — `_build_stati_by_computer` falls back to "implicitly built" when a computer has test_instances on this commit but no explicit `compiled` signal. A bare singleton with no instances still falls through to `:unknown`.
- `spec/models/commit_state_spec.rb` — two new specs in `#build_status` (implicit-built + still-unknown guard) and one in `#per_computer_summary` covering the regression.
- `app/helpers/test_instances_helper.rb` — new `best_branch_name_for(commit)` helper, prefers `main` then alphabetical.
- `app/models/test_instance.rb` — `.query` now eager-loads `commit: :branches` so the search view doesn't N+1.
- `app/views/test_instances/search.html.haml` — uses the helper for commit + test_case links.

## Test plan

- [x] `bundle exec rspec` — 307 examples, 0 failures
- [x] Verified `/test_instances/search?query_text=computer:VVEEGGAA` links resolve to containing branches:
  - `0671b8f` → `/pgplot_residuals/commits/0671b8f`
  - `43db327` → `/features/nialljmiller/customcolors_post/commits/43db327`
  - `250d865`, `aa27a08` → `/main/commits/...`
- [x] Verified VVEEGGAA now visible on all four commit pages (was hidden on 3 of 4 before)
  - `0671b8f`: BUILDS 0/0 → 1/1, 0 computers → 1
  - `250d865`: BUILDS 2/2 → 3/3, 2 computers → 3
  - `43db327`: VVEEGGAA column now present
  - `aa27a08`: still works (had explicit `compiled=true` separately)