### PR TITLE
Redirect commit pages when URL branch doesn't contain the commit

### DIFF
--- a/app/controllers/commits_controller.rb
+++ b/app/controllers/commits_controller.rb
@@ -1,23 +1,31 @@
 class CommitsController < ApplicationController
   include LogProxy
+  include BranchMismatchRedirect
 
   skip_before_action :authorize_user, only: :show, if: :root_page?
   before_action :set_commit, only: :show
   layout "modern", only: [:index, :show]
 
   # Branch lookup for the commit detail page. The :branch URL segment
-  # might disagree with where the commit actually lives — old branch
-  # got merged, user typed a typo, etc. If we can't find the branch
-  # named in the URL but the commit does live on `main`, prefer that;
-  # otherwise fall back to whatever branch first claims the commit.
-  # In either fallback case we redirect so the URL agrees with the
-  # branch we ended up using.
+  # might disagree with where the commit actually lives — branch got
+  # deleted, user typed a typo, or a stale link points at a branch
+  # the commit was never on (e.g. the cherry-picked SHA went into a
+  # feature branch while the old URL still says `main`). In any of
+  # those cases we redirect to a branch that actually contains the
+  # commit (`Commit#preferred_branch`) and surface a flash explaining
+  # what happened — both the requested branch and the alternatives.
   def show
     @selected_branch = Branch.includes(:head).named(CGI.unescape(params[:branch]))
-    unless @selected_branch
-      @selected_branch = Branch.main if @commit.branches.include?(Branch.main)
-      @selected_branch ||= @commit.branches.first
-      redirect_to(commit_path(sha: @commit.short_sha, branch: @selected_branch.name), alert: "Branch <span class='text-monospace'>#{CGI.unescape(params[:branch])}</span> does not exist. Found commit in <span class='text-monospace'>#{@selected_branch}</span>.") and return
+    if branch_mismatch?(@selected_branch, @commit)
+      target = @commit.preferred_branch
+      return render_404("Commit '#{@commit.short_sha}' is not on any branch") unless target
+      flash[:warning] = branch_mismatch_message(
+        requested_name: CGI.unescape(params[:branch]),
+        requested_branch: @selected_branch,
+        target: target,
+        commit: @commit
+      )
+      redirect_to(commit_path(sha: @commit.short_sha, branch: target.name)) and return
     end
 
     # Two-section picker: branches that actually contain this

--- a/app/controllers/concerns/branch_mismatch_redirect.rb
+++ b/app/controllers/concerns/branch_mismatch_redirect.rb
@@ -1,0 +1,28 @@
+module BranchMismatchRedirect
+  extend ActiveSupport::Concern
+
+  private
+
+  # True when the resolved branch needs to be replaced with a
+  # containing one — either it doesn't exist as a Branch record, or
+  # it exists but doesn't include this commit.
+  def branch_mismatch?(selected_branch, commit)
+    selected_branch.nil? || !commit.branches.include?(selected_branch)
+  end
+
+  # Human-readable flash for the branch-mismatch redirect. Plain text
+  # (no inline HTML); the layout escapes flash values.
+  def branch_mismatch_message(requested_name:, requested_branch:, target:, commit:)
+    others = commit.branches.reject { |b| b == target }.map(&:name).sort
+    suffix = others.any? ? " Also on: #{others.join(', ')}." : ""
+
+    reason =
+      if requested_branch.nil?
+        "Branch '#{requested_name}' doesn't exist."
+      else
+        "Branch '#{requested_name}' doesn't contain commit #{commit.short_sha}."
+      end
+
+    "#{reason} Showing it on '#{target.name}' instead.#{suffix}"
+  end
+end

--- a/app/controllers/test_case_commits_controller.rb
+++ b/app/controllers/test_case_commits_controller.rb
@@ -1,6 +1,7 @@
 class TestCaseCommitsController < ApplicationController
   include TestCaseCommitsHelper
   include LogProxy
+  include BranchMismatchRedirect
 
   # Log-type whitelist + per-type display vocabulary for the
   # per-test log proxy. Keys match the `:type` route segment;
@@ -19,7 +20,22 @@ class TestCaseCommitsController < ApplicationController
 
   def show
     @selected_branch = Branch.named(params[:branch])
-    return render_404("Branch '#{params[:branch]}' not found") unless @selected_branch
+    if branch_mismatch?(@selected_branch, @commit)
+      target = @commit.preferred_branch
+      return render_404("Commit '#{@commit.short_sha}' is not on any branch") unless target
+      flash[:warning] = branch_mismatch_message(
+        requested_name: CGI.unescape(params[:branch]),
+        requested_branch: @selected_branch,
+        target: target,
+        commit: @commit
+      )
+      redirect_to(test_case_commit_path(
+        sha: @commit.short_sha,
+        branch: target.name,
+        module: @test_case.module,
+        test_case: @test_case.name
+      )) and return
+    end
 
     # Other branches that contain this commit, for the breadcrumb's
     # branch picker. Mirrors the pattern used on commits#show.

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -698,6 +698,20 @@ class Commit < ApplicationRecord
     compile_stati.count(false)
   end
 
+  # Pick the branch this commit should display under when a caller
+  # doesn't have a strong preference (e.g. the controllers' branch-
+  # mismatch redirect, or a URL builder that has a commit but no
+  # branch in hand). Prefers `main` when the commit lives there;
+  # otherwise picks the branch whose head was most recently active
+  # (alphabetical tiebreaker). Returns nil when the commit isn't on
+  # any branch — the caller decides whether that's a 404.
+  def preferred_branch
+    candidates = branches.includes(:head).to_a
+    return nil if candidates.empty?
+    candidates.find { |b| b.name == 'main' } ||
+      candidates.min_by { |b| [-(b.head&.commit_time&.to_i || 0), b.name] }
+  end
+
   # branches that this commit is NOT in, in two categories:
   # - branches that have been recently updated
   # - branches that have not been recently updated

--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -61,4 +61,48 @@ RSpec.describe Commit, type: :model do
       expect(commit.fine_resolution?).to be false
     end
   end
+
+  describe '#preferred_branch' do
+    it 'returns nil when the commit is on no branches' do
+      commit = create(:commit)
+      expect(commit.preferred_branch).to be_nil
+    end
+
+    it 'prefers main when the commit lives there' do
+      main = create(:branch, name: 'main')
+      feature = create(:branch, name: 'feature/x')
+      commit = create(:commit)
+      [main, feature].each { |b| BranchMembership.create!(branch: b, commit: commit) }
+
+      expect(commit.preferred_branch).to eq(main)
+    end
+
+    it 'picks the branch with the most-recent head when main is absent' do
+      old_head = create(:commit, commit_time: 10.days.ago)
+      new_head = create(:commit, commit_time: 1.day.ago)
+      old_branch = create(:branch, name: 'z-old', head: old_head)
+      new_branch = create(:branch, name: 'a-new', head: new_head)
+      BranchMembership.create!(branch: old_branch, commit: old_head)
+      BranchMembership.create!(branch: new_branch, commit: new_head)
+
+      orphan = create(:commit)
+      BranchMembership.create!(branch: old_branch, commit: orphan)
+      BranchMembership.create!(branch: new_branch, commit: orphan)
+
+      # Most-recent-head wins despite alphabetical order putting old first.
+      expect(orphan.preferred_branch).to eq(new_branch)
+    end
+
+    it 'falls back to alphabetical order when heads tie on time' do
+      shared_head = create(:commit, commit_time: 1.day.ago)
+      a_branch = create(:branch, name: 'a-branch', head: shared_head)
+      b_branch = create(:branch, name: 'b-branch', head: shared_head)
+
+      commit = create(:commit)
+      BranchMembership.create!(branch: a_branch, commit: commit)
+      BranchMembership.create!(branch: b_branch, commit: commit)
+
+      expect(commit.preferred_branch).to eq(a_branch)
+    end
+  end
 end

--- a/spec/requests/page_renders_spec.rb
+++ b/spec/requests/page_renders_spec.rb
@@ -62,6 +62,63 @@ RSpec.describe 'Page renders', type: :request do
 
       expect(response).to have_http_status(:ok)
     end
+
+    context 'branch-mismatch redirect' do
+      let(:feature_branch) { create(:branch, name: 'feature/x') }
+      let(:other_commit) do
+        c = create(:commit)
+        BranchMembership.create!(branch: feature_branch, commit: c)
+        feature_branch.update!(head: c)
+        c
+      end
+
+      it 'redirects to a containing branch when the URL branch does not contain the commit' do
+        get "/main/commits/#{other_commit.short_sha}"
+
+        expect(response).to redirect_to("/feature%2Fx/commits/#{other_commit.short_sha}")
+        expect(flash[:warning]).to include("Branch 'main' doesn't contain")
+        expect(flash[:warning]).to include(other_commit.short_sha)
+        expect(flash[:warning]).to include("'feature/x'")
+      end
+
+      it 'redirects to main when main contains the commit and the URL branch does not exist' do
+        get "/no-such-branch/commits/#{commit.short_sha}"
+
+        expect(response).to redirect_to("/main/commits/#{commit.short_sha}")
+        expect(flash[:warning]).to include("Branch 'no-such-branch' doesn't exist")
+        expect(flash[:warning]).to include("'main'")
+      end
+
+      it 'lists other containing branches in the flash when there are multiple' do
+        also = create(:branch, name: 'jenkins')
+        BranchMembership.create!(branch: also, commit: commit)
+
+        get "/no-such-branch/commits/#{commit.short_sha}"
+
+        expect(flash[:warning]).to include("Also on: jenkins")
+      end
+
+      it 'picks the most-recent-head branch when main is not a candidate' do
+        old_branch = create(:branch, name: 'a-old')
+        new_branch = create(:branch, name: 'z-new')
+        old_head = create(:commit, commit_time: 10.days.ago)
+        new_head = create(:commit, commit_time: 1.day.ago)
+        BranchMembership.create!(branch: old_branch, commit: old_head)
+        BranchMembership.create!(branch: new_branch, commit: new_head)
+        old_branch.update!(head: old_head)
+        new_branch.update!(head: new_head)
+
+        orphan = create(:commit)
+        BranchMembership.create!(branch: old_branch, commit: orphan)
+        BranchMembership.create!(branch: new_branch, commit: orphan)
+
+        get "/main/commits/#{orphan.short_sha}"
+
+        # main doesn't contain orphan; of the two that do, z-new's head is
+        # more recent than a-old's, so it wins despite alphabetical order.
+        expect(response).to redirect_to("/z-new/commits/#{orphan.short_sha}")
+      end
+    end
   end
 
   describe 'GET /:branch/commits' do
@@ -85,6 +142,21 @@ RSpec.describe 'Page renders', type: :request do
       get "/main/commits/#{commit.short_sha}/test_cases/#{test_case.module}/#{test_case.name}"
 
       expect(response).to have_http_status(:ok)
+    end
+
+    it 'redirects to a containing branch when the URL branch does not contain the commit' do
+      feature_branch = create(:branch, name: 'feature/x')
+      other_commit = create(:commit)
+      BranchMembership.create!(branch: feature_branch, commit: other_commit)
+      feature_branch.update!(head: other_commit)
+      TestCaseCommit.create!(test_case: test_case, commit: other_commit)
+
+      get "/main/commits/#{other_commit.short_sha}/test_cases/#{test_case.module}/#{test_case.name}"
+
+      expect(response).to redirect_to(
+        "/feature%2Fx/commits/#{other_commit.short_sha}/test_cases/#{test_case.module}/#{test_case.name}"
+      )
+      expect(flash[:warning]).to include("Branch 'main' doesn't contain")
     end
   end
 


### PR DESCRIPTION
## Summary

- `CommitsController#show` and `TestCaseCommitsController#show` now redirect to a containing branch whenever the URL's `:branch` segment doesn't include this commit — not just when the branch doesn't exist as a record. A flash banner explains the mismatch and lists the branches the commit is actually on.
- New `Commit#preferred_branch`: prefers `main`, then the branch with the most-recent head, alphabetical tiebreaker.
- New `BranchMismatchRedirect` concern keeps the predicate + flash builder in one place.

## Background

A user reported that [`/main/commits/de16d72`](https://testhub.mesastar.org/main/commits/de16d72) rendered de16d72 "on main" even though it lives only on `feature/superad-turnover-time-limiter`. The existing fallback at [commits_controller.rb:18](app/controllers/commits_controller.rb#L18) only fired when the URL branch wasn't a valid Branch record. If the user typed (or was sent) a URL where `main` existed but didn't contain the SHA, no redirect happened — and the page silently presented the commit under the wrong branch's subway map, neighbors, and last-clean-commit.

Now any URL whose branch segment doesn't contain the commit redirects to one that does, with a flash like:

> Branch 'main' doesn't contain commit de16d72. Showing it on 'feature/superad-turnover-time-limiter' instead.

When the URL branch *doesn't* exist (the pre-existing case), the flash flips to "Branch 'X' doesn't exist." and the redirect target follows the same precedence. Multi-branch commits get an "Also on:" suffix so the user can pick another branch.

## Changes

- `app/models/commit.rb` — `#preferred_branch` returning a Branch (or nil for unbranched commits).
- `app/controllers/concerns/branch_mismatch_redirect.rb` — shared `branch_mismatch?` + `branch_mismatch_message`.
- `app/controllers/commits_controller.rb` — folded the old "no such branch" redirect into the same flow; uses `preferred_branch`. A commit on zero branches now 404s instead of crashing on `nil.name`.
- `app/controllers/test_case_commits_controller.rb` — same fallback, carrying the test_case + module through the redirect.
- Specs: `spec/models/commit_spec.rb` covers the four `preferred_branch` cases (no branches / main present / most-recent-head wins / alphabetical tiebreaker); `spec/requests/page_renders_spec.rb` covers the four request cases (branch doesn't contain / branch doesn't exist / multi-branch "Also on" / most-recent-head over alphabetical) plus the TCC variant.

## Test plan

- [x] `bundle exec rspec` — 313 examples, 0 failures
- [x] Verified `/main/commits/de16d72` redirects to `/feature%2Fsuperad-turnover-time-limiter/commits/de16d72` with the expected warning flash
- [x] Verified `/totally-fake-branch/commits/aa27a08` still redirects to `/main/commits/aa27a08` (pre-existing case) with updated phrasing
- [x] Verified `/main/commits/aa27a08` (valid URL) renders with no flash
- [x] Verified `/main/commits/de16d72/test_cases/star/1.4M_ms_op_mono` redirects to the same path under the containing branch