### PR TITLE
Render search-result runtimes from runtime_minutes

### DIFF
--- a/app/models/test_instance.rb
+++ b/app/models/test_instance.rb
@@ -427,20 +427,14 @@ class TestInstance < ApplicationRecord
       SearchOption.new('re_RAM', self, :mem_re, true) do |mem_GB|
         mem_GB.to_f * (1024**2)
       end,
-      # Runtime SearchOptions all share parse_runtime — accepts integer
-      # seconds or natural phrasings like "1 hr 30 min". The columns are
-      # `runtime_seconds` (rn step), `re_time` (re step), and
-      # `total_runtime_seconds` (whole test). There is no
-      # total_runtime_minutes column — relying on the like-named instance
-      # method would break inside a where clause.
-      SearchOption.new('rn_runtime', self, :runtime_seconds, true) do |runtime_str|
-        TestInstance.parse_runtime(runtime_str)
-      end,
-      SearchOption.new('re_runtime', self, :re_time, true) do |runtime_str|
-        TestInstance.parse_runtime(runtime_str)
-      end,
-      SearchOption.new('runtime', self, :total_runtime_seconds, true) do |runtime_str|
-        TestInstance.parse_runtime(runtime_str)
+      # `runtime` queries `runtime_minutes`, the one runtime column the
+      # ingest pipeline actually populates (summed from instance_inlists
+      # in `build_instance`). `runtime_seconds`, `re_time`, and
+      # `total_runtime_seconds` exist in the schema from a long-ago
+      # refactor but are never written. `parse_runtime` returns seconds
+      # — convert to minutes for the column.
+      SearchOption.new('runtime', self, :runtime_minutes, true) do |runtime_str|
+        TestInstance.parse_runtime(runtime_str) / 60.0
       end,
       SearchOption.new('date', self, :created_at, true) do |datestring|
         Date.parse(datestring)

--- a/app/views/test_instances/search.html.haml
+++ b/app/views/test_instances/search.html.haml
@@ -88,7 +88,7 @@
           %dl.space-y-2
             = render "field_row", field: "platform", desc: "Computer platform: macOS or linux. No version string."
             = render "field_row", field: "platform_version", desc: "Platform version, e.g. 14.5 or Ubuntu 22.04."
-            = render "field_row", field: "rn_runtime / re_runtime / runtime", desc: "Runtime for rn / re scripts or whole test. Integer seconds or '1 hr 30 min', '2.3 hours', etc."
+            = render "field_row", field: "runtime", desc: "Total test runtime. Integer seconds or '1 hr 30 min', '2.3 hours', etc."
             = render "field_row", field: "rn_RAM / re_RAM", desc: "Peak memory for rn / re scripts, in GB."
             = render "field_row", field: "threads", desc: "Number of OpenMP threads used."
             = render "field_row", field: "compiler", desc: "Compiler family, e.g. SDK, gfortran, ifort."
@@ -126,7 +126,7 @@
               %th.text-left.px-3.py-2.font-medium.border-b.border-border-subtle.whitespace-nowrap Computer
               %th.text-left.px-3.py-2.font-medium.border-b.border-border-subtle.whitespace-nowrap User
               %th.text-left.px-3.py-2.font-medium.border-b.border-border-subtle.whitespace-nowrap Submitted
-              %th.text-right.px-3.py-2.font-medium.border-b.border-border-subtle.whitespace-nowrap Runtime (s)
+              %th.text-right.px-3.py-2.font-medium.border-b.border-border-subtle.whitespace-nowrap Runtime (min)
               %th.text-right.px-3.py-2.font-medium.border-b.border-border-subtle.whitespace-nowrap RAM (GB)
               %th.text-left.px-3.py-2.font-medium.border-b.border-border-subtle.whitespace-nowrap Compiler
               %th.text-left.px-3.py-2.font-medium.border-b.border-border-subtle.whitespace-nowrap Platform
@@ -163,11 +163,16 @@
                 %td.px-3.text-fg-muted.whitespace-nowrap{ class: "text-[12px] tabular-nums" }
                   = format_time_tag(ti.created_at)
                 %td.px-3.text-right.font-mono.tabular-nums.whitespace-nowrap{ class: "text-[12px]" }
-                  = ti.runtime_seconds || 0
-                  %span.text-fg-subtle  /
-                  = ti.re_time || 0
-                  %span.text-fg-subtle  /
-                  = ti.total_runtime_seconds || 0
+                  -# `runtime_minutes` is the only runtime column the ingest
+                  -# pipeline populates (summed from instance_inlists in
+                  -# TestInstance.build_instance). `runtime_seconds`, `re_time`,
+                  -# and `total_runtime_seconds` are dead schema columns from
+                  -# a long-ago refactor and are always nil; matching the
+                  -# test_case_commit cell renderer keeps the two views in sync.
+                  - if ti.runtime_minutes
+                    = sprintf('%.2f', ti.runtime_minutes)
+                  - else
+                    %span.text-fg-subtle —
                 %td.px-3.text-right.font-mono.tabular-nums.whitespace-nowrap{ class: "text-[12px]" }
                   = sprintf('%.2f', ti.rn_mem_GB || 0)
                   %span.text-fg-subtle  /

--- a/spec/models/test_instance_query_spec.rb
+++ b/spec/models/test_instance_query_spec.rb
@@ -35,13 +35,23 @@ RSpec.describe TestInstance, '.query', type: :model do
   describe 'each documented search option from the help text' do
     %w[test_case commit commit_datetime passed computer user platform
        platform_version rn_RAM re_RAM threads compiler compiler_version
-       runtime rn_runtime re_runtime date datetime].each do |opt|
+       runtime date datetime].each do |opt|
       it "accepts #{opt} as a valid search key" do
         _, failures = TestInstance.query("#{opt}: foo")
         expect(failures).not_to include(opt),
           "search option `#{opt}` rejected — likely the column it points " \
           "to was renamed or removed"
       end
+    end
+
+    it 'rejects the dropped `rn_runtime` key (pointed at unpopulated runtime_seconds)' do
+      _, failures = TestInstance.query('rn_runtime: 5min')
+      expect(failures).to include('rn_runtime')
+    end
+
+    it 'rejects the dropped `re_runtime` key (pointed at unpopulated re_time)' do
+      _, failures = TestInstance.query('re_runtime: 5min')
+      expect(failures).to include('re_runtime')
     end
   end
 
@@ -169,29 +179,31 @@ RSpec.describe TestInstance, '.query', type: :model do
     end
   end
 
-  describe 'rn_runtime / re_runtime fields' do
+  describe 'runtime field' do
     let(:test_case) { create(:test_case) }
     let(:computer)  { create(:computer) }
     let(:commit)    { create(:commit) }
     let!(:slow_instance) do
       make_instance(commit: commit, computer: computer, test_case: test_case,
-                    runtime_seconds: 800, re_time: 200,
-                    total_runtime_seconds: 1000)
+                    runtime_minutes: 16.67) # ~1000s
     end
     let!(:fast_instance) do
       make_instance(commit: commit, computer: computer, test_case: test_case,
-                    runtime_seconds: 80, re_time: 20,
-                    total_runtime_seconds: 100)
+                    runtime_minutes: 1.67)  # ~100s
     end
 
-    it 'rn_runtime filters on runtime_seconds column' do
-      relation, failures = TestInstance.query('rn_runtime: 500-1000')
+    it 'filters on the runtime_minutes column with hr/min/sec syntax' do
+      # Range "5min-30min" → 5.0 to 30.0 minutes. Slow (16.67m) matches;
+      # fast (1.67m) does not.
+      relation, failures = TestInstance.query('runtime: 5min-30min')
       expect(failures).to be_empty
       expect(relation.to_a).to contain_exactly(slow_instance)
     end
 
-    it 're_runtime filters on re_time column' do
-      relation, failures = TestInstance.query('re_runtime: 150-300')
+    it 'treats bare numeric input as seconds, then converts to minutes' do
+      # parse_runtime convention: bare number = seconds. "300-2000"s →
+      # 5 to 33.3 minutes. Slow (16.67m) matches; fast (1.67m) doesn't.
+      relation, failures = TestInstance.query('runtime: 300-2000')
       expect(failures).to be_empty
       expect(relation.to_a).to contain_exactly(slow_instance)
     end


### PR DESCRIPTION
## Summary

- The Runtime column in `/test_instances/search` was reading three schema columns that the ingest pipeline never writes; every search hit displayed \"0 / 0 / 0\". Switched to `runtime_minutes` (the one column the factory actually populates).
- The runtime *filter* had the same problem — `runtime:`, `rn_runtime:`, and `re_runtime:` all queried dead columns, so any search clause containing a runtime returned nothing. Collapsed to a single `runtime` key that queries `runtime_minutes`.

## Background

`TestInstance.build_instance` initializes `runtime_minutes = 0` and then sums `inlist.runtime_minutes` across instance_inlists. It does not touch `runtime_seconds`, `re_time`, or `total_runtime_seconds` — those columns are leftovers from a long-ago refactor. DB confirms: of 872k test_instances, all 872k have `runtime_minutes` populated and zero have any of the other three.

The popover and the test_case_commit cell renderer both display from `runtime_minutes`. The search results table was the lone holdout.

## Changes

- `app/views/test_instances/search.html.haml` — single `%.2f` minutes value with em-dash fallback (matches `_instances_cell.html.haml`); header from \"Runtime (s)\" to \"Runtime (min)\"; syntax help reduced to the one working key.
- `app/models/test_instance.rb` — SearchOptions for `rn_runtime` and `re_runtime` removed (they pointed at unpopulated columns and silently returned no matches); `runtime` now queries `runtime_minutes` with `parse_runtime / 60.0`.
- `spec/models/test_instance_query_spec.rb` — covers the new runtime filter behavior and asserts the two retired keys land in the failures list.

## Test plan

- [x] \`bundle exec rspec\` — 336 examples, 0 failures
- [x] Verified \`/test_instances/search?query_text=user:Bill Wolf\` now shows real minutes (e.g. 3.05 / 0.02 / 0.89 / 3.23 / 1.68) instead of all-zero rows; header reads \"Runtime (min)\"
- [x] Verified \`runtime: 2hr-3hr; user: Bill Wolf\` returns 46 rows all in the 120–180 minute band (was 0 rows before)