### PR TITLE
Expose runtime_minutes in the search JSON envelope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,9 +226,12 @@ helper or partial exists.
   `instance_inlists.runtime_minutes`). All 870k+ rows have NULL
   in the other three columns. Anywhere that reads or filters
   runtime — the popover, the test_case_commit cell, the search
-  view, and the `runtime:` SearchOption — should hit
+  view, the `runtime:` SearchOption, and the
+  `test_instances/search.json` envelope — should hit
   `runtime_minutes`. `parse_runtime` returns seconds; divide by
-  60 when feeding it into a `runtime_minutes` query.
+  60 when feeding it into a `runtime_minutes` query. The JSON
+  surface used to emit `rn_runtime` / `re_runtime` / `runtime`
+  (all always null); it now emits `runtime_minutes` directly.
 - **Submission destroy refreshes TCC + Commit scalars in a specific
   order.** `Submission` carries `before_destroy
   :remember_affected_tcc_ids, prepend: true` (the `prepend` is

--- a/app/models/test_instance.rb
+++ b/app/models/test_instance.rb
@@ -788,6 +788,12 @@ class TestInstance < ApplicationRecord
   # here; the default makes the method callable from paths that
   # don't pass anything (which broke the JSON search endpoint as
   # soon as it had to serialize a non-empty result set).
+  #
+  # Runtime is exposed as `runtime_minutes` to match the only
+  # column the ingest pipeline actually writes; the previous
+  # `rn_runtime` / `re_runtime` / `runtime` keys all read
+  # unpopulated schema columns and were always nil regardless of
+  # how long the test took. See CLAUDE.md's runtime reality-check.
   def as_json(options = nil)
     {
       test_case: test_case.name,
@@ -800,9 +806,7 @@ class TestInstance < ApplicationRecord
       datetime: created_at,
       platform: computer.platform,
       platform_version: platform_version,
-      rn_runtime: rn_time,
-      re_runtime: re_time,
-      runtime: total_runtime_seconds,
+      runtime_minutes: runtime_minutes,
       mem_rn: rn_mem_GB,
       mem_re: re_mem_GB,
       threads: omp_num_threads,

--- a/spec/requests/test_instances_search_api_spec.rb
+++ b/spec/requests/test_instances_search_api_spec.rb
@@ -80,6 +80,26 @@ RSpec.describe 'GET /test_instances/search.json', type: :request do
     expect(body['results'].size).to eq(1)
   end
 
+  it 'serializes runtime as runtime_minutes (the only populated runtime column)' do
+    # Set the runtime on the existing main_instance so the assertion
+    # has something to read back. `update_columns` skips the build
+    # callback that would zero `runtime_minutes` from the inlists.
+    main_instance.update_columns(runtime_minutes: 12.5)
+
+    get '/test_instances/search.json', params: { query_text: 'branch: main' }
+    body = JSON.parse(response.body)
+    result = body['results'].first
+
+    expect(result).to have_key('runtime_minutes')
+    expect(result['runtime_minutes']).to eq(12.5)
+    # Confirm the old dead keys are gone — they always returned null
+    # because `runtime_seconds` / `re_time` / `total_runtime_seconds`
+    # are unpopulated columns.
+    expect(result).not_to have_key('rn_runtime')
+    expect(result).not_to have_key('re_runtime')
+    expect(result).not_to have_key('runtime')
+  end
+
   describe 'GET /test_instances/search_count.json' do
     it 'returns the count for a branch query' do
       get '/test_instances/search_count.json',


### PR DESCRIPTION
## Summary

Follow-up to [#94](https://github.com/MESAHub/MESATestHub/pull/94). The JSON path through `test_instances#search` had the same broken-runtime problem as the HTML path — `TestInstance#as_json` emitted three runtime keys (`rn_runtime`, `re_runtime`, `runtime`) backed by schema columns the ingest pipeline never writes, so all 870k+ rows serialized as `null` regardless of how long the test ran.

Replace with a single `runtime_minutes` key sourced from the column that's actually populated.

## Background

`TestInstance.build_instance` only sets `runtime_minutes` (summed from `instance_inlists.runtime_minutes`); `runtime_seconds`, `re_time`, and `total_runtime_seconds` are dead columns. No live JSON consumer can be reading the dead keys as numbers — they've always been null — so dropping them is a no-op for existing callers, and adding `runtime_minutes` gives any new caller something real to work with. `cpu_hours` (which the JSON already exposed, derived from `runtime_minutes * threads / 60`) confirms the pipeline does this conversion already.

## Changes

- `app/models/test_instance.rb` — `as_json` drops `rn_runtime` / `re_runtime` / `runtime`; adds `runtime_minutes`.
- `spec/requests/test_instances_search_api_spec.rb` — new spec asserts the key is present, carries the column value, and the three dead keys are absent.
- `CLAUDE.md` — runtime reality-check mentions the JSON surface and the key change.

## Test plan

- [x] `bundle exec rspec` — 337 examples, 0 failures