### PR TITLE
Add JSON download + mesa_test CLI hints to search results

### DIFF
--- a/app/javascript/controllers/download_json_controller.js
+++ b/app/javascript/controllers/download_json_controller.js
@@ -1,0 +1,136 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Fetches the full (non-paginated) JSON result set from
+// /test_instances/search.json and saves it as a file. Authentication
+// rides on the existing browser session — the HTML search page is
+// already gated to logged-in users, so the fetch inherits that
+// cookie. When the result set is bigger than `threshold`, ask the
+// user to confirm first via a native <dialog> modal — the server
+// will happily ship 100k rows in one envelope but the user is
+// usually better off going through `mesa_test count` first.
+//
+// Targets:
+//   button — the trigger button. We swap its label to "Preparing…"
+//            during the fetch and restore on completion. Disabled
+//            while in flight to prevent double-fires.
+//
+// Values:
+//   count     (Number) — total rows the query matches (Kaminari's
+//                        total_count from the server).
+//   threshold (Number) — show the confirm modal above this row count.
+//   query     (String) — the query_text to re-run for the JSON path.
+//   queryLabel (String) — human-readable rendering of the query
+//                         (defaults to `query`) for the modal text.
+export default class extends Controller {
+  static targets = ["button"]
+  static values = {
+    count: Number,
+    threshold: { type: Number, default: 5000 },
+    query: String,
+    queryLabel: String
+  }
+
+  async start(event) {
+    event.preventDefault()
+    if (this.countValue > this.thresholdValue) {
+      const proceed = await this._confirmLarge()
+      if (!proceed) return
+    }
+    await this._download()
+  }
+
+  // Native <dialog>-backed confirm. Returns a Promise<boolean>.
+  // Native dialog gives us focus-trap, ESC-to-cancel, and backdrop
+  // styling for free — no library, no extra DOM lifecycle to manage.
+  _confirmLarge() {
+    return new Promise((resolve) => {
+      const dialog = document.createElement("dialog")
+      dialog.className = "rounded-lg border border-border bg-bg-elev p-0 max-w-md"
+      dialog.style.boxShadow = "var(--shadow-card-lg)"
+
+      const queryLabel = this.queryLabelValue || this.queryValue || "(no query)"
+      const approxBytes = this.countValue * 800 // rough per-row average
+      const sizeMB = (approxBytes / 1024 / 1024).toFixed(1)
+
+      dialog.innerHTML = `
+        <div class="px-5 py-4 border-b border-border-subtle">
+          <div class="text-fg font-medium text-[14px]">Download ${this.countValue.toLocaleString()} test instances?</div>
+        </div>
+        <div class="px-5 py-4 space-y-3 text-[13px] text-fg-muted">
+          <p>
+            This query returns
+            <span class="font-mono text-fg">${this.countValue.toLocaleString()}</span>
+            rows. The JSON payload will be roughly
+            <span class="font-mono text-fg">${sizeMB} MB</span>
+            and will be sent in one response.
+          </p>
+          <p>
+            If you only need a sample, narrow the query first
+            (e.g., add a <span class="font-mono">commit_datetime</span> range).
+          </p>
+          <p class="text-fg-subtle text-[12px]">
+            Query: <span class="font-mono text-fg">${this._escapeHTML(queryLabel)}</span>
+          </p>
+        </div>
+        <div class="px-5 py-3 border-t border-border-subtle flex justify-end gap-2 bg-bg-subtle">
+          <button type="button" data-action="cancel" class="mesa-btn" style="padding: 5px 14px; font-size: 12px;">Cancel</button>
+          <button type="button" data-action="confirm" class="mesa-btn mesa-btn-primary" style="padding: 5px 14px; font-size: 12px;">Download anyway</button>
+        </div>
+      `
+
+      const cleanup = (result) => {
+        dialog.close()
+        dialog.remove()
+        resolve(result)
+      }
+
+      dialog.querySelector('[data-action="cancel"]').addEventListener("click", () => cleanup(false))
+      dialog.querySelector('[data-action="confirm"]').addEventListener("click", () => cleanup(true))
+      // ESC / backdrop click → cancel
+      dialog.addEventListener("cancel", (e) => { e.preventDefault(); cleanup(false) })
+      dialog.addEventListener("click", (e) => { if (e.target === dialog) cleanup(false) })
+
+      document.body.appendChild(dialog)
+      dialog.showModal()
+    })
+  }
+
+  async _download() {
+    const btn = this.hasButtonTarget ? this.buttonTarget : this.element
+    const originalLabel = btn.querySelector("[data-label]")?.textContent
+    if (originalLabel) btn.querySelector("[data-label]").textContent = "Preparing…"
+    btn.disabled = true
+
+    try {
+      const url = `/test_instances/search.json?query_text=${encodeURIComponent(this.queryValue)}`
+      const response = await fetch(url, {
+        credentials: "same-origin",
+        headers: { Accept: "application/json" }
+      })
+      if (!response.ok) {
+        alert(`Download failed (HTTP ${response.status}). Try again or pull a smaller result set via mesa_test.`)
+        return
+      }
+      const blob = await response.blob()
+      const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)
+      const a = document.createElement("a")
+      a.href = URL.createObjectURL(blob)
+      a.download = `mesa-test-instances-${stamp}.json`
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(a.href)
+    } catch (e) {
+      alert(`Download failed: ${e.message}`)
+    } finally {
+      if (originalLabel) btn.querySelector("[data-label]").textContent = originalLabel
+      btn.disabled = false
+    }
+  }
+
+  _escapeHTML(s) {
+    const div = document.createElement("div")
+    div.textContent = s
+    return div.innerHTML
+  }
+}

--- a/app/views/test_instances/search.html.haml
+++ b/app/views/test_instances/search.html.haml
@@ -112,9 +112,59 @@
           %span.ml-2.text-fg{ class: "text-[14px]" }
             = pluralize(@test_instances.total_count, "test instance")
             matched
-        - if @test_instances.total_pages > 1
-          %span.text-fg-subtle.tabular-nums{ class: "text-[11px]" }
-            = page_entries_info @test_instances
+        .flex.items-center.gap-3
+          - if @test_instances.total_pages > 1
+            %span.text-fg-subtle.tabular-nums{ class: "text-[11px]" }
+              = page_entries_info @test_instances
+          -# Download-as-JSON pulls the full (non-paginated) result
+          -# set through the same /search.json endpoint that
+          -# `mesa_test search` hits. Above the threshold the
+          -# Stimulus controller throws up a confirm modal — a
+          -# user accidentally clicking "Download" on a 100k-row
+          -# query would otherwise stall the tab for a while.
+          %button.mesa-btn{ type: "button",
+                            style: "padding: 4px 10px; font-size: 12px;",
+                            data: { controller: "download-json",
+                                    download_json_count_value: @test_instances.total_count,
+                                    download_json_query_value: params[:query_text].to_s,
+                                    download_json_query_label_value: params[:query_text].to_s,
+                                    download_json_button_target: "button",
+                                    action: "click->download-json#start" } }
+            = mesa_icon(:download, size: 12)
+            %span{ data: { label: true } } Download JSON
+
+      -# Discoverability for devs writing their own scripts. Closed
+      -# by default so the typical "look at one query in the browser"
+      -# user doesn't see it; one click to reveal the equivalent
+      -# `mesa_test` invocations + the count-first guidance.
+      - cli_query = params[:query_text].to_s
+      - count_cmd = %(mesa_test count "#{cli_query.gsub('"', '\\"')}")
+      - search_cmd = %(mesa_test search "#{cli_query.gsub('"', '\\"')}")
+      %details.border-b.border-border-subtle
+        %summary.flex.items-center.justify-between.gap-2.px-4.py-2.cursor-pointer.text-fg-muted.hover:bg-bg-muted{ class: "text-[12px] [&::-webkit-details-marker]:hidden" }
+          %span.flex.items-center.gap-2
+            = mesa_icon(:chevron, size: 10)
+            %span Use this query from
+            %span.font-mono.text-fg mesa_test
+          %span.text-fg-subtle{ class: "text-[11px]" } CLI
+        .px-4.py-3.space-y-3.bg-bg-subtle{ class: "text-[12px]" }
+          %p.text-fg-muted
+            Run
+            %span.font-mono.text-fg count
+            first to size the result set;
+            %span.font-mono.text-fg search
+            returns every matching row in one JSON payload.
+          - [["count", count_cmd], ["search", search_cmd]].each do |label, cmd|
+            .flex.items-stretch.gap-2
+              .flex-1.font-mono.text-fg.bg-bg-elev.border.border-border.rounded-md.px-3.py-2.overflow-x-auto.whitespace-nowrap{ class: "text-[12px]" }= cmd
+              %button.mesa-btn{ type: "button",
+                                style: "padding: 4px 12px; font-size: 12px;",
+                                title: "Copy #{label} command",
+                                data: { controller: "copy-button",
+                                        copy_button_text_value: cmd,
+                                        action: "click->copy-button#copy" } }
+                = mesa_icon(:copy, size: 12)
+                %span{ data: { copy_button_target: "label" } } Copy
 
       %div{ style: "overflow-x: auto;" }
         %table.w-full.border-collapse{ style: "min-width: 1000px;" }


### PR DESCRIPTION
## Summary

Two discoverability surfaces on the test-instance search results page, aimed at devs building their own automated surveillance:

1. **Download JSON** button — pulls the full non-paginated result set through `/test_instances/search.json` (the same envelope `mesa_test` consumes) and saves it as a timestamped file. Above 5,000 rows, a confirm modal lists the row count + estimated payload size + the query before pulling.

2. **\"Use this query from mesa_test\" details panel** — closed by default, one click to reveal a count-first tip and two copyable commands (`mesa_test count \"<query>\"` and `mesa_test search \"<query>\"`).

Both surfaces only render when the query produced at least one result, so pre-query and empty-state views stay clean.

## Design notes

- Auth: the download fetch uses session cookies (`credentials: 'same-origin'`). The HTML page is already gated to logged-in users; no need to put credentials in the URL.
- Modal: native `<dialog>` element — focus trap, ESC-to-cancel, and backdrop-click-to-cancel all come for free. No JS library, no new infrastructure.
- Threshold (5,000 rows): lives in `data-download-json-threshold-value`, easy to tune. ~0.8 KB/row × 5,000 ≈ 4 MB JSON, which felt like the right \"are you sure?\" line.
- The two copy buttons re-use the existing `copy-button` Stimulus controller fixed in [5c2a4b2](https://github.com/MESAHub/MESATestHub/commit/5c2a4b2).
- The CLI commands wrap the query in double quotes and escape any embedded quotes — `mesa_test count \"computer:VVEEGGAA\"` lands as a single shell argument.

## Test plan

- [x] \`bundle exec rspec\` — 337 examples, 0 failures
- [x] Browser-verified the small-result path: 112-row download completes, blob filename is timestamped, JSON parses to `{results: [...], failures: []}` with 112 entries each carrying `runtime_minutes` (post-PR-#95 shape)
- [x] Browser-verified the threshold modal: temporarily lowered threshold, click triggers dialog with correct row count + size estimate + query; Cancel dismisses cleanly
- [x] Browser-verified the details panel: closed by default, opens to reveal both copyable commands with the query properly quoted
- [x] Visual check (screenshots in PR comments): results header doesn't feel junky, modal is centered and legible