### PR TITLE
Dispatcher + claims, Phases A and B

### DIFF
--- a/app/controllers/api/v1/claims_controller.rb
+++ b/app/controllers/api/v1/claims_controller.rb
@@ -1,0 +1,161 @@
+# Phase B of the dispatcher + claims feature
+# (docs/dispatcher-and-claims.md). Records a computer's intent to
+# do a piece of work — either build a commit (`scope='build'`) or
+# run one test case on a commit (`scope='test'`) — and starts the
+# wall-clock TTL via `Claim.default_expires_at`. The dispatcher
+# endpoint that *recommends* what to claim lives in Phase C and is
+# deliberately separate from this one (see "Dispatch vs. claim
+# creation" in the design doc).
+#
+# Authentication mirrors `SubmissionsController` exactly: a
+# `submitter:` hash carrying `email` / `password` / `computer`,
+# with the password verified by bcrypt against the User and the
+# computer scoped to the authenticated user's computers. The same
+# `submitter_params` shape lets `mesa_test` reuse its existing
+# credential plumbing.
+module Api
+  module V1
+    class ClaimsController < ApplicationController
+      skip_before_action :authorize_user
+      skip_before_action :verify_authenticity_token, only: [:create]
+
+      def create
+        return unless authenticate_claim
+        return unless validate_scope
+
+        if @scope == 'test'
+          return unless resolve_test_case_commit
+        end
+
+        claim = Claim.new(
+          computer: @computer,
+          commit: @commit,
+          test_case_commit: @tcc,
+          scope: @scope,
+          status: 'pending',
+          use_fpe: bool_param(:use_fpe),
+          use_full_inlists: bool_param(:use_full_inlists),
+          use_converge: bool_param(:use_converge),
+          dispatched_at: parse_iso_datetime(claim_params[:dispatched_at]),
+          expires_at: Claim.default_expires_at(scope: @scope)
+        )
+
+        if claim.save
+          render json: { claim_id: claim.id,
+                         expires_at: claim.expires_at.iso8601 },
+                 status: :created
+        else
+          render json: { error: claim.errors.full_messages.join('; ') },
+                 status: :unprocessable_content
+        end
+      end
+
+      private
+
+      # Same shape as SubmissionsController#authenticate_submission:
+      # verify the user, scope the computer to that user, and look
+      # up the commit by SHA. Returns true on success; sets a JSON
+      # error response and returns false on any failure.
+      def authenticate_claim
+        return claim_fail(:auth, 'Invalid e-mail or password.') unless authenticated?
+
+        @computer = @user.computers.find_by(name: submitter_params[:computer])
+        return claim_fail(:auth, "User #{@user.email} doesn't control computer " \
+                                 "#{submitter_params[:computer]}.") unless @computer
+
+        @commit = Commit.find_by(sha: claim_params[:commit_sha])
+        return claim_fail(:not_found,
+                          "Unknown commit SHA: #{claim_params[:commit_sha]}.") unless @commit
+
+        true
+      end
+
+      def authenticated?
+        @user = current_user
+        return true if @user
+
+        @user = User.find_by(email: submitter_params[:email])
+        @user && @user.authenticate(submitter_params[:password])
+      end
+
+      def validate_scope
+        @scope = claim_params[:scope].to_s
+        return true if Claim::SCOPES.include?(@scope)
+
+        claim_fail(:bad_request,
+                   "Invalid scope: #{@scope.inspect}. " \
+                   "Must be one of #{Claim::SCOPES.inspect}.")
+      end
+
+      # For scope='test', the request carries a (module, name) pair
+      # identifying the test case. Look up the matching TCC on the
+      # claimed commit. Unlike the submissions path, this endpoint
+      # does NOT lazily create a TCC — TCCs are guaranteed to exist
+      # by the topology sync at commit ingest, so a missing one
+      # means either a stale client or a test case that doesn't
+      # apply to this commit, both of which the client should hear
+      # about explicitly.
+      def resolve_test_case_commit
+        mod  = claim_params[:test_case_module].to_s
+        name = claim_params[:test_case_name].to_s
+        return claim_fail(:bad_request,
+                          'test_case_module and test_case_name are required ' \
+                          'for scope=test.') if mod.empty? || name.empty?
+
+        @tcc = @commit.test_case_commits
+                       .joins(:test_case)
+                       .find_by(test_cases: { module: mod, name: name })
+
+        return true if @tcc
+
+        claim_fail(:not_found,
+                   "No test case commit found for #{mod}/#{name} on " \
+                   "#{@commit.short_sha}.")
+      end
+
+      # Render an error and return false so callers can early-exit
+      # with `return unless ...`. Status codes:
+      #   :auth      → 422 (unprocessable_content) — matches the
+      #               legacy submissions endpoint's auth-failure shape
+      #   :not_found → 404 — for missing commit / TCC
+      #   :bad_request → 422 — malformed request body
+      def claim_fail(kind, message)
+        status = case kind
+                 when :not_found then :not_found
+                 else :unprocessable_content
+                 end
+        render json: { error: message }, status: status
+        false
+      end
+
+      def submitter_params
+        params.require(:submitter).permit(:email, :password, :computer)
+      end
+
+      def claim_params
+        params.require(:claim).permit(
+          :commit_sha, :scope,
+          :test_case_module, :test_case_name,
+          :use_fpe, :use_full_inlists, :use_converge,
+          :dispatched_at
+        )
+      end
+
+      # Coerces a JSON boolean (true/false/0/1/"true"/etc.) to a
+      # Ruby boolean. Returns false rather than nil when the key
+      # isn't present — claims' `use_*` columns are NOT NULL and
+      # default to false, so an absent key means "false," not
+      # "unknown."
+      def bool_param(key)
+        ActiveModel::Type::Boolean.new.cast(claim_params[key]) || false
+      end
+
+      def parse_iso_datetime(value)
+        return nil if value.blank?
+        Time.zone.parse(value.to_s)
+      rescue ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/app/controllers/commits_controller.rb
+++ b/app/controllers/commits_controller.rb
@@ -113,7 +113,9 @@ class CommitsController < ApplicationController
                     .reorder('commits.commit_time ASC')
                     .limit(@page_size + 1)
                     .includes(:submissions,
-                              test_case_commits: { test_instances: [] })
+                              :pending_claims,
+                              test_case_commits: [:test_instances,
+                                                  :pending_claims])
                     .to_a
       @has_more_newer = rows.size > @page_size
       rows.pop if @has_more_newer
@@ -127,7 +129,9 @@ class CommitsController < ApplicationController
                     .where('commits.commit_time < ?', @before_time_param)
                     .limit(@page_size + 1)
                     .includes(:submissions,
-                              test_case_commits: { test_instances: [] })
+                              :pending_claims,
+                              test_case_commits: [:test_instances,
+                                                  :pending_claims])
                     .to_a
       @has_more_older_via_main_fetch = rows.size > @page_size
       rows.pop if @has_more_older_via_main_fetch

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -19,6 +19,16 @@ class SubmissionsController < ApplicationController
     @submission.sdk_version = commit_params[:sdk_version]
     @submission.math_backend = commit_params[:math_backend]
 
+    # Dispatcher + claims fulfillment payload (Phase B of
+    # docs/dispatcher-and-claims.md). Optional — backwards-
+    # compatible with mesa_test versions that don't send a
+    # `claim:` block. When a claim_id is supplied, the
+    # after_create_commit callback on Submission flips the
+    # matching claim to fulfilled. The `use_*` flags record what
+    # the work was actually run with (used by Phase C's
+    # satisfaction tracking).
+    assign_claim_fulfillment(@submission)
+
     # only report compilation status once per go-round
     # that is, if we're reporting results test-by-test, compilation information
     # will come in an empty submission. In an entire submission, all the tests
@@ -290,5 +300,31 @@ class SubmissionsController < ApplicationController
   def request_commit_params
     params.permit(:allow_optional, :allow_fpe, :allow_converge, :allow_skip,
                   :max_age, :branch)
+  end
+
+  # Pulls the optional `claim:` block out of the request and
+  # writes its fields onto the submission. JSON shape:
+  #
+  #   "claim": {
+  #     "id": 8421,                          // integer, optional
+  #     "started_at": "2026-05-27T12:34:56Z",
+  #     "use_fpe": false,
+  #     "use_full_inlists": false,
+  #     "use_converge": false
+  #   }
+  #
+  # No-op when no `claim:` key is present, so legacy mesa_test
+  # versions continue to work. The `id`-vs-`claim_id` rename keeps
+  # the JSON nested-namespace tidy (`claim.id`) while the column on
+  # `submissions` stays `claim_id`.
+  def assign_claim_fulfillment(submission)
+    return unless params[:claim]
+
+    attrs = params.require(:claim).permit(
+      :id, :started_at,
+      :use_fpe, :use_full_inlists, :use_converge
+    ).to_h
+    attrs[:claim_id] = attrs.delete(:id) if attrs.key?(:id) || attrs.key?('id')
+    submission.assign_attributes(attrs)
   end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -3,12 +3,13 @@
 # test case on a commit). See docs/dispatcher-and-claims.md for
 # the design.
 #
-# Phase A's claim is purely a data object — the dispatcher and
-# expiry sweeper that operate on it land in Phases B and C. The
-# model carries the validations + associations needed so a row is
-# always self-consistent: scope/TCC coherence, and the invariant
-# that a test-scope claim's TCC belongs to the same commit the
-# claim points at.
+# Created via POST /api/v1/claims (Phase B) — the controller writes
+# the row and starts the wall-clock TTL via
+# `Claim.default_expires_at`. Fulfilled by an `after_create_commit`
+# callback on Submission when a submission arrives carrying the
+# claim's id; the same callback handles the `expired → fulfilled`
+# transition for legitimately-late submissions. Pending claims past
+# `expires_at` get swept to `expired` by `rake claims:sweep`.
 #
 # The CHECK constraint `claims_scope_fk_coherence` enforces the
 # scope/TCC pairing at the database level; the model validation is
@@ -17,6 +18,17 @@
 class Claim < ApplicationRecord
   SCOPES   = %w[build test].freeze
   STATUSES = %w[pending fulfilled expired].freeze
+
+  # V1 TTLs (docs/dispatcher-and-claims.md "TTLs"): builds are
+  # always quick, so 15 min is plenty; tests can legitimately run
+  # for hours, and short TTLs would produce noisy false
+  # expirations. Phase E swaps the test side for a historical-
+  # runtime calculation; the build side stays fixed because the
+  # easy case doesn't need help.
+  TTL_FOR_SCOPE = {
+    'build' => 15.minutes,
+    'test'  => 12.hours
+  }.freeze
 
   belongs_to :computer
   belongs_to :commit
@@ -34,6 +46,41 @@ class Claim < ApplicationRecord
   scope :pending,   -> { where(status: 'pending') }
   scope :fulfilled, -> { where(status: 'fulfilled') }
   scope :expired,   -> { where(status: 'expired') }
+
+  # Wall-clock expiration for a freshly-created claim. The TTL
+  # constants live on this model so the controller doesn't
+  # duplicate them at the HTTP boundary.
+  def self.default_expires_at(scope:)
+    TTL_FOR_SCOPE.fetch(scope).from_now
+  end
+
+  # Forward-transition `pending → expired` for every claim whose
+  # `expires_at` has passed. Bulk UPDATE backed by
+  # `index_claims_on_expires_at_pending` (the partial index on
+  # `expires_at` scoped to `status = 'pending'`). Driven by
+  # `rake claims:sweep` from Railway cron; safe to call any time,
+  # including in-process from a spec.
+  #
+  # Returns the number of rows transitioned. Does NOT touch
+  # `fulfilled` claims (a late-submission reactivation isn't an
+  # expiration) or claims already swept.
+  def self.sweep_expired!(now: Time.current)
+    pending.where('expires_at < ?', now)
+           .update_all(status: 'expired', updated_at: now)
+  end
+
+  # Flip the claim to `fulfilled`. Idempotent across the two legal
+  # starting states (pending OR expired) — a late submission that
+  # arrives after the sweeper has flipped the claim to `expired`
+  # legitimately flips it back to `fulfilled` (lifecycle diagram in
+  # docs/dispatcher-and-claims.md). Uses update_columns so a stale
+  # `updated_at` race against the sweeper can't reject the write,
+  # and so AR validations on `status` never see the transient state.
+  def fulfill!(at: Time.current)
+    update_columns(status: 'fulfilled',
+                   fulfilled_at: at,
+                   updated_at: Time.current)
+  end
 
   private
 

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -1,0 +1,69 @@
+# Records a computer's intent to do a specific piece of work
+# (`scope='build'`: build a commit; `scope='test'`: run a single
+# test case on a commit). See docs/dispatcher-and-claims.md for
+# the design.
+#
+# Phase A's claim is purely a data object — the dispatcher and
+# expiry sweeper that operate on it land in Phases B and C. The
+# model carries the validations + associations needed so a row is
+# always self-consistent: scope/TCC coherence, and the invariant
+# that a test-scope claim's TCC belongs to the same commit the
+# claim points at.
+#
+# The CHECK constraint `claims_scope_fk_coherence` enforces the
+# scope/TCC pairing at the database level; the model validation is
+# the friendly user-facing version (returns a validation error
+# instead of raising a Postgres exception).
+class Claim < ApplicationRecord
+  SCOPES   = %w[build test].freeze
+  STATUSES = %w[pending fulfilled expired].freeze
+
+  belongs_to :computer
+  belongs_to :commit
+  belongs_to :test_case_commit, optional: true
+
+  has_one :submission, dependent: :nullify
+
+  validates :scope,      inclusion: { in: SCOPES }
+  validates :status,     inclusion: { in: STATUSES }
+  validates :expires_at, presence: true
+
+  validate :scope_and_tcc_coherent
+  validate :tcc_commit_matches_claim_commit
+
+  scope :pending,   -> { where(status: 'pending') }
+  scope :fulfilled, -> { where(status: 'fulfilled') }
+  scope :expired,   -> { where(status: 'expired') }
+
+  private
+
+  # Mirrors the `claims_scope_fk_coherence` CHECK constraint, but
+  # surfaces as an ActiveRecord validation error so callers see
+  # `Claim#errors` rather than an `ActiveRecord::StatementInvalid`.
+  def scope_and_tcc_coherent
+    case scope
+    when 'build'
+      if test_case_commit_id.present?
+        errors.add(:test_case_commit_id,
+                   "must be blank for build-scope claims")
+      end
+    when 'test'
+      if test_case_commit_id.blank?
+        errors.add(:test_case_commit_id,
+                   "is required for test-scope claims")
+      end
+    end
+  end
+
+  # `commit_id` is denormalized on every claim row so "all claims
+  # on this SHA" is a single index lookup, not a join. That
+  # convenience only holds if the claim's commit_id stays in sync
+  # with its TCC's commit_id — guard it here.
+  def tcc_commit_matches_claim_commit
+    return unless scope == 'test'
+    return if test_case_commit.blank?
+    return if test_case_commit.commit_id == commit_id
+    errors.add(:test_case_commit,
+               "must belong to the claim's commit")
+  end
+end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -30,6 +30,11 @@ class Commit < ApplicationRecord
 
   # Dispatcher/claims feature — see docs/dispatcher-and-claims.md.
   has_many :claims, dependent: :destroy
+  # Pre-filtered association for the "is anyone working on this
+  # commit right now?" question. Cheap to eager-load on the commits
+  # index without sucking in the entire claim history of the SHA.
+  has_many :pending_claims, -> { where(status: 'pending') },
+                            class_name: 'Claim'
 
   validates_uniqueness_of :sha, :short_sha
   validates_presence_of :sha, :short_sha, :author, :author_email, :message,
@@ -650,6 +655,24 @@ class Commit < ApplicationRecord
     matchgroup = CommitMessageFlags::FULL_INLISTS_RE.match(message)
     return nil unless matchgroup && matchgroup[1]
     matchgroup[1].strip.to_i
+  end
+
+  # True iff at least one computer has registered a (still-live)
+  # claim against this commit — either build-scope or test-scope.
+  # The `pending_claims` association is pre-filtered to
+  # `status='pending'`, so this is a cheap presence check that
+  # plays nicely with `.includes(:pending_claims)` on the index
+  # page (no N+1 fan-out across 25 rows).
+  #
+  # Used by the `tests_status` aggregator in CommitState to
+  # distinguish "fresh commit, nobody's working on it yet"
+  # (`:not_run`) from "fresh commit, someone has started"
+  # (`:pending`). Before claims existed, the only signal we had
+  # for the latter was "TCC status is -1" — which fires
+  # immediately at commit ingest, well before any human has
+  # touched the SHA. Claims give us the real signal.
+  def has_pending_claims?
+    pending_claims.loaded? ? pending_claims.any? : pending_claims.exists?
   end
 
 

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -28,6 +28,9 @@ class Commit < ApplicationRecord
   has_many :test_cases, through: :test_case_commits
   has_many :test_instances, through: :test_case_commits
 
+  # Dispatcher/claims feature — see docs/dispatcher-and-claims.md.
+  has_many :claims, dependent: :destroy
+
   validates_uniqueness_of :sha, :short_sha
   validates_presence_of :sha, :short_sha, :author, :author_email, :message,
     :commit_time
@@ -318,15 +321,23 @@ class Commit < ApplicationRecord
     # on the branch — that's what makes the head sit at the top of
     # GitHub's view and is what we want every commit-list view here
     # to agree on.
+    #
+    # CI directive flags are parsed from the message body here so
+    # both ingest paths (insert_all in ingest_payload_commits and
+    # ActiveRecord update in create_or_update_from_github_hash) get
+    # the columns populated automatically. Keeps the source of truth
+    # for ci_skip / wants_* a single function call away from the
+    # message text.
+    message = github_hash[:commit][:message]
     {
       sha: github_hash[:sha],
       short_sha: github_hash[:sha][(0...7)],
       author: github_hash[:commit][:author][:name],
       author_email: github_hash[:commit][:author][:email],
       commit_time: github_hash[:commit][:committer][:date],
-      message: github_hash[:commit][:message],
+      message: message,
       github_url: github_hash[:html_url]
-    }
+    }.merge(CommitMessageFlags.parse(message))
   end
 
   #####################################
@@ -607,36 +618,38 @@ class Commit < ApplicationRecord
       pluck(:test_case_id).uniq.count == test_cases.count
   end
 
-  # these simply report if the right flag appears in the commit message
-  # ideally, these should be added to the database so they can be modified
-  # after the fact (and so we can change the convetion). But for now, this
-  # will suffice
+  # The four CI directives MESA developers embed in commit
+  # messages, exposed as boolean predicates. Backed by columns on
+  # `commits` that get populated at ingest by
+  # `CommitMessageFlags.parse` — these predicates are pass-throughs
+  # to the columns so the same answer goes to the dispatcher (which
+  # filters/boosts in SQL) and to the legacy `test_candidate` /
+  # submissions API surface that historically read them at runtime.
+  #
+  # `ci_optional_n` still parses the message because the digit in
+  # `[ci optional 1234]` isn't stored as a scalar.
   def ci_skip?
-    # ensure that anything including optional or fpe tests is not thought
-    # of as being skipped; usually only appears in merge commit messages
-    !!(message =~ /\[\s*ci\s+skip\s*\]/ && !(ci_optional? || ci_fpe?))
+    ci_skip
   end
 
   def ci_optional?
-    !!(message =~ /\[\s*ci\s+optional(\s+\d+)?\s*\]/)
+    wants_full_inlists
+  end
+
+  def ci_fpe?
+    wants_fpe
+  end
+
+  def ci_converge?
+    wants_converge
   end
 
   # extract the number from a run-optional commit, if there is one
   def ci_optional_n
     return unless ci_optional?
-    matchgroup = /\[\s*ci\s+optional(\s+\d+)?\s*\]/.match(message)
-    if matchgroup[1]
-      return matchgroup[1].strip.to_i
-    end
-    return nil
-  end
-
-  def ci_fpe?
-    !!(message =~ /\[\s*ci\s+fpe\s*\]/)
-  end
-
-  def ci_converge?
-    !!(message =~ /\[\s*ci\s+converge\s*\]/)
+    matchgroup = CommitMessageFlags::FULL_INLISTS_RE.match(message)
+    return nil unless matchgroup && matchgroup[1]
+    matchgroup[1].strip.to_i
   end
 
 

--- a/app/models/computer.rb
+++ b/app/models/computer.rb
@@ -2,6 +2,7 @@ class Computer < ApplicationRecord
   has_many :submissions, dependent: :destroy
   has_many :test_instances, through: :submissions, dependent: :destroy
   has_many :instance_inlists, through: :test_instances
+  has_many :claims, dependent: :destroy
   belongs_to :user
   validates_presence_of :name
   validates_uniqueness_of :name

--- a/app/models/concerns/commit_state.rb
+++ b/app/models/concerns/commit_state.rb
@@ -32,10 +32,21 @@ module CommitState
   #
   #   :fail            ≥1 test case failed uniformly on every computer that ran it
   #   :mixed           ≥1 test case passed on some computers, failed on others
-  #   :pending         test runs are still going, nothing passing yet
+  #   :pending         work is in flight — at least one live claim is open
+  #                    on this commit and the test side isn't done yet
   #   :pending_partial pending + some already passed
   #   :all_pass        every test case ran and passed
-  #   :not_run         no tests ran (typically because all builds failed)
+  #   :not_run         no tests ran AND no claims are open (genuinely
+  #                    untouched — typically a brand-new commit or one
+  #                    whose builds all failed)
+  #
+  # The `:pending` / `:not_run` split keys on `has_pending_claims?`,
+  # not on "are there untested TCCs?". Before claims existed, the
+  # only signal we had for "in flight" was "the TCC has no
+  # submissions yet," which fires the instant a commit is ingested
+  # — well before any computer has actually started work. Claims
+  # are the real signal: a commit with no claims is genuinely
+  # untouched, even if it has 500 TCCs sitting at status=-1.
   #
   # See app/models/test_case_commit.rb for the underlying status integer
   # vocabulary (-1 untested, 0 passing, 1 failing, 2 mixed_checksums,
@@ -44,13 +55,13 @@ module CommitState
     counts = _test_case_status_counts
 
     has_uniform_fail = counts[:failing] > 0
-    has_mixed = counts[:mixed] > 0
-    has_pending = counts[:untested] > 0
-    has_passing = counts[:passing] > 0 || counts[:mixed_checksums] > 0
+    has_mixed        = counts[:mixed] > 0
+    has_passing      = counts[:passing] > 0 || counts[:mixed_checksums] > 0
+    has_pending      = counts[:untested] > 0 && has_pending_claims?
 
     case build_status
     when :all_fail, :unknown
-      return :not_run if !has_passing && !has_uniform_fail && !has_mixed
+      return :not_run if !has_passing && !has_uniform_fail && !has_mixed && !has_pending
     end
 
     return :fail if has_uniform_fail
@@ -105,6 +116,8 @@ module CommitState
     pending_tests = 0
     passing_tests = 0
 
+    pending_tcc_test_ids = _pending_claim_test_case_ids
+
     cells_by_test.each do |test_id, row|
       pendings = row.count { |_id, cell| cell[:status] == :pending }
       passes = row.count   { |_id, cell| cell[:status] == :pass }
@@ -133,11 +146,22 @@ module CommitState
         # Pass with no failures — the test is passing regardless of
         # pending neighbors.
         passing_tests += 1
-      elsif pendings.positive? || no_data
-        # Truly unresolved: nothing passing, nothing failing, just
-        # pending submissions (or no data at all).
+      elsif pendings.positive?
+        # Cell-level pending: at least one built computer hasn't
+        # reported a result yet. Counts as test-level pending
+        # regardless of whether there's an explicit claim — the
+        # build submission is the signal.
+        pending_tests += 1
+      elsif no_data && pending_tcc_test_ids.include?(test_id)
+        # No cells (no built-computer is even attempting yet) AND
+        # someone has claimed the test → genuine in-flight pending.
         pending_tests += 1
       end
+      # no_data without a claim → not counted; the test is :not_run,
+      # not :pending. Pre-claims this branch silently bucketed every
+      # untouched test into pending_tests, which inflated the hero
+      # tile for freshly-ingested commits and for builds-all-failed
+      # commits that nobody's retrying.
     end
 
     has_uniform_fail = uniform_failing_tests.positive?
@@ -548,8 +572,26 @@ module CommitState
 
   # Cached for the lifetime of the Commit instance. Same eager-loaded
   # association set used by the matrix and popover-data passes.
+  # `pending_claims` is included so the row-classification loop in
+  # `commit_state` can ask each TCC "is anyone actually working on
+  # you?" without firing a query per test case.
   def _tccs_for_matrix
-    @_tccs_for_matrix ||= test_case_commits.includes(:test_case, :test_instances).to_a
+    @_tccs_for_matrix ||= test_case_commits
+                            .includes(:test_case, :test_instances, :pending_claims)
+                            .to_a
+  end
+
+  # `test_case_id` set for every TCC on this commit that currently
+  # has a pending test-scope claim. Used in the row-classification
+  # loop in `commit_state` to distinguish "no data on this test
+  # because no one is working on it" (counts as :not_run) from "no
+  # data on this test because the work is still in flight" (counts
+  # as :pending).
+  def _pending_claim_test_case_ids
+    @_pending_claim_test_case_ids ||= _tccs_for_matrix
+                                        .select(&:has_pending_claims?)
+                                        .map(&:test_case_id)
+                                        .to_set
   end
 
   # A cell is "clean" (skip popover) iff it passed with no flags.

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,6 +1,7 @@
 class Submission < ApplicationRecord
   belongs_to :commit
   belongs_to :computer
+  belongs_to :claim, optional: true
   has_one :user, through: :computer
 
   # deleting the submission deletes all associated test instances

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -15,6 +15,14 @@ class Submission < ApplicationRecord
   before_destroy :remember_affected_tcc_ids, prepend: true
   after_commit :update_commit
 
+  # Phase B of docs/dispatcher-and-claims.md. When a submission
+  # arrives carrying a claim_id (mesa_test ≥ vNEXT), flip the
+  # matching claim to `fulfilled`. Fires only on the create commit
+  # so a subsequent update / destroy doesn't trigger a stale write.
+  # The `pending → fulfilled` and `expired → fulfilled` transitions
+  # are both legal; `Claim#fulfill!` handles them uniformly.
+  after_create_commit :fulfill_claim, if: -> { claim_id.present? }
+
   paginates_per 25
 
   # Inclusive of both endpoints. Either bound is optional — pass nil
@@ -95,6 +103,14 @@ class Submission < ApplicationRecord
   end
 
   private
+
+  # Flip the referenced claim to `fulfilled`. Both the
+  # `if: -> { claim_id.present? }` guard on the callback and the
+  # FK to `claims.id` guarantee the association resolves — no
+  # safe-nav needed.
+  def fulfill_claim
+    claim.fulfill!
+  end
 
   # On destroy, capture the IDs of the TCCs this submission's
   # test_instances point at — `dependent: :destroy` will wipe the

--- a/app/models/test_case_commit.rb
+++ b/app/models/test_case_commit.rb
@@ -6,6 +6,7 @@ class TestCaseCommit < ApplicationRecord
   has_many :inlist_data, through: :instance_inlists
   has_many :submissions, through: :test_instances
   has_many :computers, through: :test_instances
+  has_many :claims, dependent: :destroy
 
   validates_presence_of :status, :submission_count, :commit_id, :test_case_id,
                         :checksum_count

--- a/app/models/test_case_commit.rb
+++ b/app/models/test_case_commit.rb
@@ -7,6 +7,11 @@ class TestCaseCommit < ApplicationRecord
   has_many :submissions, through: :test_instances
   has_many :computers, through: :test_instances
   has_many :claims, dependent: :destroy
+  # Pre-filtered association for "is anyone running this specific
+  # test on this commit right now?" Eager-loaded by the commits
+  # index alongside Commit#pending_claims.
+  has_many :pending_claims, -> { where(status: 'pending') },
+                            class_name: 'Claim'
 
   validates_presence_of :status, :submission_count, :commit_id, :test_case_id,
                         :checksum_count
@@ -184,6 +189,25 @@ class TestCaseCommit < ApplicationRecord
 
   def failing
     test_instances.where(passed: false)
+  end
+
+  # True iff at least one computer has registered a still-live
+  # test-scope claim against this TCC. Cheap to check after an
+  # `.includes(:pending_claims)` on the commit's collection. Used
+  # by view-side aggregators that want to distinguish "this test
+  # hasn't been touched on this commit" from "this test is being
+  # worked on right now" without changing the integer status
+  # column (which still encodes pass/fail/mixed/untested).
+  def has_pending_claims?
+    pending_claims.loaded? ? pending_claims.any? : pending_claims.exists?
+  end
+
+  # True iff this TCC is in an "untested" state (no submissions)
+  # AND someone has claimed it. The two-part check is the entire
+  # point: a fresh TCC with no claim is genuinely untested; a
+  # fresh TCC with an open claim is pending.
+  def pending?
+    status == @@status_encoder[:untested] && has_pending_claims?
   end
 
   # Display payload for the test-on-commit page. Returns one hash per

--- a/app/services/commit_message_flags.rb
+++ b/app/services/commit_message_flags.rb
@@ -1,0 +1,58 @@
+# Parse CI directive flags out of the first line of a MESA commit
+# message.
+#
+# Returns a hash mirroring the four boolean columns on `commits`:
+#
+#   {
+#     ci_skip:            Boolean,
+#     wants_full_inlists: Boolean,
+#     wants_fpe:          Boolean,
+#     wants_converge:     Boolean
+#   }
+#
+# Only the first line is scanned. Squash and merge commits routinely
+# list every constituent commit's subject in their body, which would
+# otherwise pull every `[ci ...]` directive from every squashed
+# commit into the merge — leading to a single landed PR claiming
+# `[ci skip]` AND `[ci fpe]` AND `[ci optional]` because some PR
+# branch commit mentioned each of them. The MESA convention is to
+# place directives in the subject line of the actual commit they
+# apply to.
+#
+# `[ci skip]` is suppressed when the same line also requests
+# `[ci optional]` or `[ci fpe]` — this catches the edge case of a
+# subject like `Merge X [ci skip] [ci optional]` where the
+# directives contradict. `[ci converge]` is not part of that
+# suppression set, matching the existing legacy behavior in
+# app/models/commit.rb.
+#
+# Hooked into the ingest path via `Commit.hash_from_github`, which
+# is the single chokepoint feeding both `insert_all` (bulk webhook
+# sync) and `create_or_update_from_github_hash` (one-off fetches).
+module CommitMessageFlags
+  SKIP_RE           = /\[\s*ci\s+skip\s*\]/.freeze
+  FULL_INLISTS_RE   = /\[\s*ci\s+optional(\s+\d+)?\s*\]/.freeze
+  FPE_RE            = /\[\s*ci\s+fpe\s*\]/.freeze
+  CONVERGE_RE       = /\[\s*ci\s+converge\s*\]/.freeze
+
+  def self.parse(message)
+    # `String#lines.first` returns the leading line *with* its
+    # trailing newline; `to_s` collapses the nil result from an
+    # empty/nil message to "". Trailing whitespace doesn't affect
+    # any of the four regexes, so no chomp needed.
+    first_line = message.to_s.lines.first.to_s
+
+    wants_full_inlists = !!(first_line =~ FULL_INLISTS_RE)
+    wants_fpe          = !!(first_line =~ FPE_RE)
+    wants_converge     = !!(first_line =~ CONVERGE_RE)
+    ci_skip            = !!(first_line =~ SKIP_RE) &&
+                         !(wants_full_inlists || wants_fpe)
+
+    {
+      ci_skip: ci_skip,
+      wants_full_inlists: wants_full_inlists,
+      wants_fpe: wants_fpe,
+      wants_converge: wants_converge
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,18 @@ Rails.application.routes.draw do
   get 'submissions/request_commit.json', to: 'submissions#request_commit'
   resources :submissions, only: [:create, :show], defaults: { formats: :json }
 
+  # Phase B of the dispatcher + claims feature
+  # (docs/dispatcher-and-claims.md). The dispatcher endpoint that
+  # *recommends* what to claim lands in Phase C and gets mounted
+  # alongside this one. New surface lives under /api/v1/ rather
+  # than the legacy flat namespace; existing endpoints stay where
+  # they are to preserve the mesa_test contract.
+  namespace :api do
+    namespace :v1 do
+      resources :claims, only: [:create], defaults: { format: :json }
+    end
+  end
+
   # JSON-only view of one submission from a computer. Used by the
   # test client: SubmissionsController#create echoes this URL
   # (with `.json`) back in the create response, and the client

--- a/db/migrate/20260528150845_create_claims_and_ci_flag_columns.rb
+++ b/db/migrate/20260528150845_create_claims_and_ci_flag_columns.rb
@@ -1,0 +1,123 @@
+# Phase A of the dispatcher + claims feature
+# (docs/dispatcher-and-claims.md). Lays the schema groundwork:
+#
+#   1. `claims` table — first-class record of "computer X has
+#      registered intent to do piece-of-work Y on commit Z".
+#      Scoped to either a full build or a single test case (TCC).
+#   2. Flag/satisfaction columns on `commits` — parsed at ingest
+#      from the commit message body, so the future dispatcher can
+#      boost `[ci optional]` / `[ci fpe]` / `[ci converge]` commits
+#      and exclude `[ci skip]` ones in a single index lookup.
+#   3. Flag/claim columns on `submissions` — needed so that a
+#      submission can both fulfill a claim and report which flags
+#      the run was executed with (to mark the parent commit's
+#      preference as satisfied).
+#
+# Backfills the four flag booleans on existing commits via
+# Postgres POSIX regex against the FIRST LINE of the commit
+# message (split_part on \n). MESA convention is that directives
+# live in the subject line of the commit they apply to; squash and
+# merge commits otherwise inherit every directive from every
+# constituent commit and the columns become noise. The patterns
+# match the `CommitMessageFlags.parse` regexes exactly so the
+# columns agree with what the parser would emit — including the
+# `[ci skip]` suppression when the line also mentions
+# `[ci optional]` or `[ci fpe]` (ignored on `[ci converge]` to
+# preserve the legacy behavior in app/models/commit.rb).
+class CreateClaimsAndCiFlagColumns < ActiveRecord::Migration[8.0]
+  def up
+    create_table :claims do |t|
+      t.references :computer, null: false, foreign_key: true
+      t.references :commit,   null: false, foreign_key: true
+      # set when scope='test', null when scope='build'
+      t.references :test_case_commit, foreign_key: true
+
+      t.string  :scope,  null: false                 # 'build' | 'test'
+      t.string  :status, null: false, default: 'pending'
+                                                     # 'pending' | 'fulfilled' | 'expired'
+
+      t.boolean :use_fpe,           default: false, null: false
+      t.boolean :use_full_inlists,  default: false, null: false
+      t.boolean :use_converge,      default: false, null: false
+
+      t.datetime :dispatched_at     # null if claim wasn't dispatcher-originated
+      t.datetime :expires_at, null: false
+      t.datetime :fulfilled_at      # null until submission arrives
+
+      t.timestamps
+    end
+
+    add_index :claims, [:commit_id, :status]
+    add_index :claims, [:computer_id, :status]
+    add_index :claims, [:test_case_commit_id, :status]
+    add_index :claims, :expires_at,
+              where: "status = 'pending'",
+              name: "index_claims_on_expires_at_pending"
+
+    # scope='build' carries no TCC; scope='test' must.
+    # commit_id is always set (even on test-scope claims) so
+    # "all claims on this SHA" is a single index lookup, not a
+    # join through test_case_commits. The model-level validation
+    # backs this up by asserting tcc.commit_id == claim.commit_id.
+    execute <<~SQL
+      ALTER TABLE claims
+      ADD CONSTRAINT claims_scope_fk_coherence CHECK (
+        (scope = 'build' AND test_case_commit_id IS NULL) OR
+        (scope = 'test'  AND test_case_commit_id IS NOT NULL)
+      )
+    SQL
+
+    add_column :commits, :ci_skip,                 :boolean, default: false, null: false
+    add_column :commits, :wants_full_inlists,      :boolean, default: false, null: false
+    add_column :commits, :wants_fpe,               :boolean, default: false, null: false
+    add_column :commits, :wants_converge,          :boolean, default: false, null: false
+    add_column :commits, :full_inlists_satisfied_at, :datetime
+    add_column :commits, :fpe_satisfied_at,          :datetime
+    add_column :commits, :converge_satisfied_at,     :datetime
+
+    add_reference :submissions, :claim, foreign_key: true
+    add_column :submissions, :started_at,        :datetime
+    add_column :submissions, :use_fpe,           :boolean, default: false, null: false
+    add_column :submissions, :use_full_inlists,  :boolean, default: false, null: false
+    add_column :submissions, :use_converge,      :boolean, default: false, null: false
+
+    # Backfill — populate the new wants_* / ci_skip columns on every
+    # existing commit by matching the same regex shapes the parser
+    # uses, scoped to the first line of the message
+    # (`split_part(message, E'\n', 1)`). Done in two statements so
+    # wants_full_inlists / wants_fpe are set before ci_skip reads
+    # them for the suppression rule.
+    say_with_time "Backfilling commit flag columns from first line" do
+      execute <<~SQL
+        UPDATE commits SET
+          wants_full_inlists = (split_part(message, E'\\n', 1) ~ '\\[[[:space:]]*ci[[:space:]]+optional([[:space:]]+[0-9]+)?[[:space:]]*\\]'),
+          wants_fpe          = (split_part(message, E'\\n', 1) ~ '\\[[[:space:]]*ci[[:space:]]+fpe[[:space:]]*\\]'),
+          wants_converge     = (split_part(message, E'\\n', 1) ~ '\\[[[:space:]]*ci[[:space:]]+converge[[:space:]]*\\]')
+      SQL
+
+      execute <<~SQL
+        UPDATE commits SET
+          ci_skip = (split_part(message, E'\\n', 1) ~ '\\[[[:space:]]*ci[[:space:]]+skip[[:space:]]*\\]')
+                    AND NOT (wants_full_inlists OR wants_fpe)
+      SQL
+    end
+  end
+
+  def down
+    remove_column :submissions, :use_converge
+    remove_column :submissions, :use_full_inlists
+    remove_column :submissions, :use_fpe
+    remove_column :submissions, :started_at
+    remove_reference :submissions, :claim, foreign_key: true
+
+    remove_column :commits, :converge_satisfied_at
+    remove_column :commits, :fpe_satisfied_at
+    remove_column :commits, :full_inlists_satisfied_at
+    remove_column :commits, :wants_converge
+    remove_column :commits, :wants_fpe
+    remove_column :commits, :wants_full_inlists
+    remove_column :commits, :ci_skip
+
+    drop_table :claims
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_25_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_28_150845) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -30,6 +30,30 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_25_000000) do
     t.datetime "created_at", precision: nil, default: -> { "now()" }, null: false
     t.datetime "updated_at", precision: nil, default: -> { "now()" }, null: false
     t.index ["name"], name: "index_branches_on_name", unique: true
+  end
+
+  create_table "claims", force: :cascade do |t|
+    t.bigint "computer_id", null: false
+    t.bigint "commit_id", null: false
+    t.bigint "test_case_commit_id"
+    t.string "scope", null: false
+    t.string "status", default: "pending", null: false
+    t.boolean "use_fpe", default: false, null: false
+    t.boolean "use_full_inlists", default: false, null: false
+    t.boolean "use_converge", default: false, null: false
+    t.datetime "dispatched_at"
+    t.datetime "expires_at", null: false
+    t.datetime "fulfilled_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["commit_id", "status"], name: "index_claims_on_commit_id_and_status"
+    t.index ["commit_id"], name: "index_claims_on_commit_id"
+    t.index ["computer_id", "status"], name: "index_claims_on_computer_id_and_status"
+    t.index ["computer_id"], name: "index_claims_on_computer_id"
+    t.index ["expires_at"], name: "index_claims_on_expires_at_pending", where: "((status)::text = 'pending'::text)"
+    t.index ["test_case_commit_id", "status"], name: "index_claims_on_test_case_commit_id_and_status"
+    t.index ["test_case_commit_id"], name: "index_claims_on_test_case_commit_id"
+    t.check_constraint "scope::text = 'build'::text AND test_case_commit_id IS NULL OR scope::text = 'test'::text AND test_case_commit_id IS NOT NULL", name: "claims_scope_fk_coherence"
   end
 
   create_table "commit_relations", force: :cascade do |t|
@@ -61,6 +85,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_25_000000) do
     t.integer "status", default: 0
     t.boolean "pull_request", default: false
     t.boolean "open"
+    t.boolean "ci_skip", default: false, null: false
+    t.boolean "wants_full_inlists", default: false, null: false
+    t.boolean "wants_fpe", default: false, null: false
+    t.boolean "wants_converge", default: false, null: false
+    t.datetime "full_inlists_satisfied_at"
+    t.datetime "fpe_satisfied_at"
+    t.datetime "converge_satisfied_at"
     t.index ["sha"], name: "index_commits_on_sha", unique: true
     t.index ["short_sha"], name: "index_commits_on_short_sha", unique: true
   end
@@ -119,6 +150,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_25_000000) do
     t.string "sdk_version"
     t.string "math_backend"
     t.string "platform_version"
+    t.bigint "claim_id"
+    t.datetime "started_at"
+    t.boolean "use_fpe", default: false, null: false
+    t.boolean "use_full_inlists", default: false, null: false
+    t.boolean "use_converge", default: false, null: false
+    t.index ["claim_id"], name: "index_submissions_on_claim_id"
     t.index ["commit_id"], name: "index_submissions_on_commit_id"
     t.index ["computer_id", "created_at"], name: "index_submissions_on_computer_id_and_created_at"
     t.index ["computer_id"], name: "index_submissions_on_computer_id"
@@ -210,11 +247,15 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_25_000000) do
   end
 
   add_foreign_key "branches", "commits", column: "head_id"
+  add_foreign_key "claims", "commits"
+  add_foreign_key "claims", "computers"
+  add_foreign_key "claims", "test_case_commits"
   add_foreign_key "commit_relations", "commits", column: "child_id"
   add_foreign_key "commit_relations", "commits", column: "parent_id"
   add_foreign_key "computers", "users", on_delete: :cascade
   add_foreign_key "inlist_data", "instance_inlists"
   add_foreign_key "instance_inlists", "test_instances"
+  add_foreign_key "submissions", "claims"
   add_foreign_key "submissions", "commits"
   add_foreign_key "submissions", "computers"
   add_foreign_key "test_case_commits", "commits"

--- a/lib/tasks/claims_sweep.rake
+++ b/lib/tasks/claims_sweep.rake
@@ -1,0 +1,20 @@
+# Sweep pending claims past their `expires_at` to `expired`.
+# Phase B of docs/dispatcher-and-claims.md. Cheap: a single
+# indexed UPDATE backed by `index_claims_on_expires_at_pending`
+# (a partial index on expires_at, scoped to `status = 'pending'`).
+#
+# Run from Railway cron every ~5 minutes:
+#   bundle exec rake claims:sweep
+#
+# The `expired → fulfilled` reverse transition (legitimate late
+# submission) is handled by the Submission after_create_commit
+# callback on Submission, not here — this task only forward-
+# transitions pending → expired.
+namespace :claims do
+  desc 'Mark pending claims past their expires_at as expired.'
+  task sweep: :environment do
+    now = Time.current
+    n = Claim.sweep_expired!(now: now)
+    puts "Swept #{n} expired claim(s) at #{now.iso8601}."
+  end
+end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -1,0 +1,29 @@
+FactoryBot.define do
+  factory :claim do
+    association :computer
+    association :commit
+    scope { 'build' }
+    status { 'pending' }
+    expires_at { 15.minutes.from_now }
+
+    trait :test_scope do
+      scope { 'test' }
+      # TCC gets created on the same commit as the claim so the
+      # tcc_commit_matches_claim_commit validation passes.
+      after(:build) do |claim, _ev|
+        claim.test_case_commit ||= create(:test_case_commit,
+                                          commit: claim.commit)
+      end
+    end
+
+    trait :fulfilled do
+      status { 'fulfilled' }
+      fulfilled_at { Time.current }
+    end
+
+    trait :expired do
+      status { 'expired' }
+      expires_at { 5.minutes.ago }
+    end
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -134,4 +134,87 @@ RSpec.describe Claim, type: :model do
         .from(claim.id).to(nil)
     end
   end
+
+  describe '.default_expires_at' do
+    it 'returns ~15 minutes from now for build scope' do
+      expect(Claim.default_expires_at(scope: 'build'))
+        .to be_within(2.seconds).of(15.minutes.from_now)
+    end
+
+    it 'returns ~12 hours from now for test scope' do
+      expect(Claim.default_expires_at(scope: 'test'))
+        .to be_within(2.seconds).of(12.hours.from_now)
+    end
+
+    it 'raises on an unknown scope' do
+      expect { Claim.default_expires_at(scope: 'audit') }
+        .to raise_error(KeyError)
+    end
+  end
+
+  describe '#fulfill!' do
+    let(:claim) { create(:claim, computer: computer, commit: commit) }
+
+    it 'flips a pending claim to fulfilled and stamps fulfilled_at' do
+      claim.fulfill!
+      claim.reload
+      expect(claim.status).to eq('fulfilled')
+      expect(claim.fulfilled_at).to be_within(2.seconds).of(Time.current)
+    end
+
+    it 'flips an expired claim to fulfilled (legitimate late submission)' do
+      claim.update_columns(status: 'expired')
+      claim.fulfill!
+      expect(claim.reload.status).to eq('fulfilled')
+    end
+
+    it 'bypasses AR validations (callable even with a stale loaded row)' do
+      # update_columns is the implementation detail that protects
+      # us from a race against the sweeper. A row that the sweeper
+      # just flipped to `expired` can still be flipped to
+      # `fulfilled` from a previously-loaded `pending` instance.
+      stale = Claim.find(claim.id)
+      Claim.where(id: claim.id).update_all(status: 'expired')
+      expect { stale.fulfill! }.not_to raise_error
+      expect(claim.reload.status).to eq('fulfilled')
+    end
+  end
+
+  describe '.sweep_expired!' do
+    let(:past)   { 1.minute.ago }
+    let(:future) { 5.minutes.from_now }
+
+    it 'flips pending claims past expires_at to expired' do
+      stale = create(:claim, computer: computer, commit: commit,
+                             expires_at: past)
+      fresh = create(:claim, computer: computer, commit: commit,
+                             expires_at: future)
+
+      expect(Claim.sweep_expired!).to eq(1)
+      expect(stale.reload.status).to eq('expired')
+      expect(fresh.reload.status).to eq('pending')
+    end
+
+    it 'leaves already-fulfilled claims alone' do
+      fulfilled = create(:claim, :fulfilled,
+                         computer: computer, commit: commit,
+                         expires_at: past)
+      Claim.sweep_expired!
+      expect(fulfilled.reload.status).to eq('fulfilled')
+    end
+
+    it 'is idempotent — a second sweep on the same window is a no-op' do
+      create(:claim, computer: computer, commit: commit, expires_at: past)
+      Claim.sweep_expired!
+      expect(Claim.sweep_expired!).to eq(0)
+    end
+
+    it 'updates updated_at on the rows it transitions' do
+      claim = create(:claim, computer: computer, commit: commit,
+                             expires_at: past,
+                             updated_at: 1.hour.ago)
+      Claim.sweep_expired!
+      expect(claim.reload.updated_at).to be_within(2.seconds).of(Time.current)
+    end
+  end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1,0 +1,137 @@
+require 'rails_helper'
+
+# Phase A spec: validates the Claim model's structural invariants —
+# associations, enum-style inclusions, and the scope/TCC coherence
+# rules that mirror the `claims_scope_fk_coherence` CHECK
+# constraint in the database. The lifecycle behavior (expiration,
+# fulfilling submissions) lands in Phase B.
+RSpec.describe Claim, type: :model do
+  let(:user)     { create(:user) }
+  let(:computer) { create(:computer, user: user) }
+  let(:commit)   { create(:commit) }
+  let(:tcc)      { create(:test_case_commit, commit: commit) }
+
+  describe 'validations' do
+    it 'is valid for a minimal build-scope claim' do
+      claim = build(:claim, computer: computer, commit: commit)
+      expect(claim).to be_valid
+    end
+
+    it 'is valid for a test-scope claim with a matching TCC' do
+      claim = build(:claim, :test_scope,
+                    computer: computer, commit: commit,
+                    test_case_commit: tcc)
+      expect(claim).to be_valid
+    end
+
+    it 'rejects an unknown scope' do
+      claim = build(:claim, computer: computer, commit: commit,
+                            scope: 'audit')
+      expect(claim).not_to be_valid
+      expect(claim.errors[:scope]).to be_present
+    end
+
+    it 'rejects an unknown status' do
+      claim = build(:claim, computer: computer, commit: commit,
+                            status: 'whoops')
+      expect(claim).not_to be_valid
+      expect(claim.errors[:status]).to be_present
+    end
+
+    it 'requires expires_at' do
+      claim = build(:claim, computer: computer, commit: commit,
+                            expires_at: nil)
+      expect(claim).not_to be_valid
+      expect(claim.errors[:expires_at]).to be_present
+    end
+
+    it 'rejects a build-scope claim that carries a TCC' do
+      claim = build(:claim, computer: computer, commit: commit,
+                            scope: 'build', test_case_commit: tcc)
+      expect(claim).not_to be_valid
+      expect(claim.errors[:test_case_commit_id]).to be_present
+    end
+
+    it 'rejects a test-scope claim without a TCC' do
+      claim = build(:claim, computer: computer, commit: commit,
+                            scope: 'test', test_case_commit: nil)
+      expect(claim).not_to be_valid
+      expect(claim.errors[:test_case_commit_id]).to be_present
+    end
+
+    it "rejects a test-scope claim whose TCC belongs to a different commit" do
+      other_commit = create(:commit)
+      other_tcc    = create(:test_case_commit, commit: other_commit)
+
+      claim = build(:claim, computer: computer, commit: commit,
+                            scope: 'test', test_case_commit: other_tcc)
+      expect(claim).not_to be_valid
+      expect(claim.errors[:test_case_commit]).to be_present
+    end
+  end
+
+  describe 'database-level scope/FK coherence' do
+    # Belt-and-suspenders: the `claims_scope_fk_coherence` CHECK
+    # backstops the model validations so direct SQL writes can't
+    # produce an incoherent row.
+    it 'raises when a build-scope row tries to carry a TCC' do
+      expect {
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          INSERT INTO claims
+            (computer_id, commit_id, test_case_commit_id,
+             scope, status, expires_at, created_at, updated_at)
+          VALUES
+            (#{computer.id}, #{commit.id}, #{tcc.id},
+             'build', 'pending', NOW(), NOW(), NOW())
+        SQL
+      }.to raise_error(ActiveRecord::StatementInvalid, /claims_scope_fk_coherence/)
+    end
+
+    it 'raises when a test-scope row omits a TCC' do
+      expect {
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          INSERT INTO claims
+            (computer_id, commit_id, test_case_commit_id,
+             scope, status, expires_at, created_at, updated_at)
+          VALUES
+            (#{computer.id}, #{commit.id}, NULL,
+             'test', 'pending', NOW(), NOW(), NOW())
+        SQL
+      }.to raise_error(ActiveRecord::StatementInvalid, /claims_scope_fk_coherence/)
+    end
+  end
+
+  describe 'scopes' do
+    it 'partitions rows by status' do
+      pending   = create(:claim, computer: computer, commit: commit)
+      fulfilled = create(:claim, :fulfilled, computer: computer,
+                                              commit: commit)
+      expired   = create(:claim, :expired, computer: computer,
+                                            commit: commit)
+
+      expect(Claim.pending).to   include(pending)
+      expect(Claim.fulfilled).to include(fulfilled)
+      expect(Claim.expired).to   include(expired)
+    end
+  end
+
+  describe 'associations' do
+    it 'destroys claims when the parent commit is destroyed' do
+      claim = create(:claim, computer: computer, commit: commit)
+      expect { commit.destroy }.to change(Claim, :count).by(-1)
+    end
+
+    it 'destroys claims when the parent computer is destroyed' do
+      claim = create(:claim, computer: computer, commit: commit)
+      expect { computer.destroy }.to change(Claim, :count).by(-1)
+    end
+
+    it 'nullifies the claim FK on its submission when the claim is destroyed' do
+      claim = create(:claim, computer: computer, commit: commit)
+      submission = create(:submission, computer: computer, commit: commit,
+                                       claim: claim)
+      expect { claim.destroy }.to change { submission.reload.claim_id }
+        .from(claim.id).to(nil)
+    end
+  end
+end

--- a/spec/models/commit_ingest_spec.rb
+++ b/spec/models/commit_ingest_spec.rb
@@ -207,4 +207,88 @@ RSpec.describe Commit, 'payload ingestion' do
         .not_to change(CommitRelation, :count)
     end
   end
+
+  # The CI directive flag columns added in Phase A of the
+  # dispatcher+claims feature get populated from the commit
+  # message at ingest. Both ingest paths run through
+  # `hash_from_github`, which merges in `CommitMessageFlags.parse`,
+  # so verifying the bulk path covers the regular AR path too.
+  describe 'CI directive flag columns at ingest' do
+    it 'populates wants_full_inlists for a [ci optional] commit' do
+      Commit.ingest_payload_commits(
+        [gh_commit(sha: sha40('opt'), message: "Refactor [ci optional]")]
+      )
+      row = Commit.find_by(sha: sha40('opt'))
+      expect(row.wants_full_inlists).to be true
+      expect(row.wants_fpe).to be false
+      expect(row.ci_skip).to be false
+    end
+
+    it 'populates wants_fpe and wants_converge together' do
+      Commit.ingest_payload_commits(
+        [gh_commit(sha: sha40('flag'),
+                   message: "Tune solver [ci fpe] [ci converge]")]
+      )
+      row = Commit.find_by(sha: sha40('flag'))
+      expect(row.wants_fpe).to be true
+      expect(row.wants_converge).to be true
+      expect(row.ci_skip).to be false
+    end
+
+    it 'populates ci_skip for a plain [ci skip] commit' do
+      Commit.ingest_payload_commits(
+        [gh_commit(sha: sha40('skip'), message: "Bump version [ci skip]")]
+      )
+      row = Commit.find_by(sha: sha40('skip'))
+      expect(row.ci_skip).to be true
+      expect(row.wants_full_inlists).to be false
+    end
+
+    it 'suppresses ci_skip when [ci optional] is also present' do
+      Commit.ingest_payload_commits(
+        [gh_commit(sha: sha40('mrge'),
+                   message: "Merge cleanup [ci skip] [ci optional]")]
+      )
+      row = Commit.find_by(sha: sha40('mrge'))
+      expect(row.ci_skip).to be false
+      expect(row.wants_full_inlists).to be true
+    end
+
+    it 'leaves all flags false for a vanilla commit' do
+      Commit.ingest_payload_commits(
+        [gh_commit(sha: sha40('clean'), message: "Add missing comma")]
+      )
+      row = Commit.find_by(sha: sha40('clean'))
+      expect(row.ci_skip).to be false
+      expect(row.wants_full_inlists).to be false
+      expect(row.wants_fpe).to be false
+      expect(row.wants_converge).to be false
+    end
+
+    it 'populates flags via the AR create_or_update path too' do
+      payload = gh_commit(sha: sha40('aronly'),
+                          message: "Big change [ci fpe]")
+      commit = Commit.create_or_update_from_github_hash(github_hash: payload)
+      expect(commit.wants_fpe).to be true
+      expect(commit.ci_skip).to be false
+    end
+
+    it 'ignores directives that appear only in the message body' do
+      # Squash/merge commits typically include each squashed
+      # commit's subject in the body. Scanning the whole message
+      # would inherit every directive from every constituent
+      # commit; only the merge commit's own subject line counts.
+      Commit.ingest_payload_commits(
+        [gh_commit(sha: sha40('mbody'),
+                   message: "Merge feature-X (#42)\n\n" \
+                            "* Tidy [ci skip]\n" \
+                            "* Solver swap [ci fpe]\n" \
+                            "* All-inlists pass [ci optional]\n")]
+      )
+      row = Commit.find_by(sha: sha40('mbody'))
+      expect(row.ci_skip).to be false
+      expect(row.wants_fpe).to be false
+      expect(row.wants_full_inlists).to be false
+    end
+  end
 end

--- a/spec/models/commit_state_spec.rb
+++ b/spec/models/commit_state_spec.rb
@@ -148,6 +148,95 @@ RSpec.describe 'commit state aggregation' do
       all_computers.each { |c| submit(computer: c, compiled: false) }
       expect(commit.reload.tests_status).to eq(:not_run)
     end
+
+    # Claim awareness: see docs/dispatcher-and-claims.md. Pre-claims,
+    # the only signal we had for "in flight" was "the TCC has no
+    # submissions yet," which fires the instant a commit is ingested.
+    # Claims give us the real signal; tests_status keys :pending /
+    # :not_run off claim presence now.
+    describe 'claim-aware pending vs not_run' do
+      it 'is :not_run for a fresh commit with TCCs but no claims' do
+        [test_case_a, test_case_b, test_case_c].each { |tc| tcc_for(tc) }
+        expect(commit.reload.tests_status).to eq(:not_run)
+      end
+
+      it 'is :pending when at least one claim is open on the commit' do
+        [test_case_a, test_case_b, test_case_c].each { |tc| tcc_for(tc) }
+        create(:claim, computer: rusty, commit: commit)
+
+        expect(commit.reload.tests_status).to eq(:pending)
+      end
+
+      it 'is :pending_partial when claims are open AND some tests have passed' do
+        [test_case_a, test_case_b, test_case_c].each { |tc| tcc_for(tc) }
+        submit(computer: rusty)
+        instance(test_case: test_case_a, computer: rusty, passed: true)
+        tcc_for(test_case_a).update_status
+        tcc_for(test_case_a).save!
+
+        create(:claim, computer: popeye, commit: commit)
+
+        expect(commit.reload.tests_status).to eq(:pending_partial)
+      end
+
+      it 'reverts to :not_run after the only open claim is fulfilled' do
+        [test_case_a, test_case_b, test_case_c].each { |tc| tcc_for(tc) }
+        claim = create(:claim, computer: rusty, commit: commit)
+        expect(commit.reload.tests_status).to eq(:pending)
+
+        claim.fulfill!
+        expect(commit.reload.tests_status).to eq(:not_run)
+      end
+
+      it 'reverts to :not_run after the only open claim expires' do
+        [test_case_a, test_case_b, test_case_c].each { |tc| tcc_for(tc) }
+        create(:claim, :expired, computer: rusty, commit: commit)
+        expect(commit.reload.tests_status).to eq(:not_run)
+      end
+    end
+  end
+
+  describe '#has_pending_claims?' do
+    it 'is false on a commit with no claims' do
+      expect(commit.has_pending_claims?).to be false
+    end
+
+    it 'is true when at least one pending claim exists' do
+      create(:claim, computer: rusty, commit: commit)
+      expect(commit.has_pending_claims?).to be true
+    end
+
+    it 'is false when the only claim has been fulfilled' do
+      create(:claim, :fulfilled, computer: rusty, commit: commit)
+      expect(commit.has_pending_claims?).to be false
+    end
+
+    it 'is false when the only claim has expired' do
+      create(:claim, :expired, computer: rusty, commit: commit)
+      expect(commit.has_pending_claims?).to be false
+    end
+
+    it 'works without preloading the association' do
+      create(:claim, computer: rusty, commit: commit)
+      expect(commit.reload.has_pending_claims?).to be true
+    end
+
+    it 'short-circuits to the loaded association when preloaded' do
+      # If `has_pending_claims?` triggered a DB query despite the
+      # preload, the commits index render path would N+1 across 25
+      # rows. Verify by clearing the connection's query cache and
+      # asserting the predicate doesn't issue a SELECT.
+      create(:claim, computer: rusty, commit: commit)
+      reloaded = Commit.includes(:pending_claims).find(commit.id)
+      query_count = 0
+      counter = ->(*, payload) {
+        query_count += 1 unless payload[:name] == "SCHEMA"
+      }
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        reloaded.has_pending_claims?
+      end
+      expect(query_count).to eq(0)
+    end
   end
 
   describe '#flag_counts' do
@@ -251,17 +340,37 @@ RSpec.describe 'commit state aggregation' do
       expect(state[:tests][:status]).to eq(:not_run)
     end
 
-    it 'counts tests with no built-computer results as pending in the hero stat row' do
-      # Every computer attempted to build and failed; the commit *has*
-      # TCCs (so we know which tests to run) but no built computer has
-      # any cell with a status. Those tests should count toward
-      # `pending_tests` so the hero's "Pending" tile flags them as
-      # missing, rather than being silently dropped.
+    it 'reports tests with no built-computer results AND no claims as not pending' do
+      # Every computer attempted to build and failed; the commit has
+      # TCCs but no claims. Pre-claims this used to lump all three
+      # tests into `pending_tests` because of the "no_data ⇒ pending"
+      # fallback in `commit_state`. With claims as the real "work in
+      # flight" signal, "all builds failed and nobody's retrying"
+      # correctly aggregates to zero pending tests (and the hero
+      # tile reads as :not_run).
       all_computers.each { |c| submit(computer: c, compiled: false) }
       [test_case_a, test_case_b, test_case_c].each { |tc| tcc_for(tc) }
 
       state = commit.reload.commit_state
-      expect(state[:tests][:pending_tests]).to eq(3)
+      expect(state[:tests][:pending_tests]).to eq(0)
+      expect(state[:tests][:status]).to eq(:not_run)
+    end
+
+    it 'counts tests with open test-scope claims as pending in the hero stat row' do
+      # Same shape as the prior test, but with two test-scope claims
+      # out on test_case_a and test_case_b. Those are the tests
+      # someone is actually working on, so they get counted; the
+      # un-claimed test_case_c does not.
+      all_computers.each { |c| submit(computer: c, compiled: false) }
+      [test_case_a, test_case_b, test_case_c].each { |tc| tcc_for(tc) }
+
+      create(:claim, :test_scope, computer: rusty, commit: commit,
+                                  test_case_commit: tcc_for(test_case_a))
+      create(:claim, :test_scope, computer: popeye, commit: commit,
+                                  test_case_commit: tcc_for(test_case_b))
+
+      state = commit.reload.commit_state
+      expect(state[:tests][:pending_tests]).to eq(2)
     end
 
     it '8e7c1b3 — passing with two full-inlist runs flagged' do
@@ -656,6 +765,56 @@ RSpec.describe TestCaseCommit, type: :model do
       expect(row[:checksum]).to eq('abc1234')
       expect(row[:steps]).to eq(1234)
       expect(row[:computer_name]).to eq('rusty')
+    end
+  end
+
+  describe '#has_pending_claims? and #pending?' do
+    let(:user) { create(:user) }
+    let(:computer) { create(:computer, user: user) }
+    let(:commit) { create(:commit) }
+    let(:test_case) { create(:test_case) }
+    let(:tcc) { create(:test_case_commit, commit: commit, test_case: test_case) }
+
+    it '#has_pending_claims? is false on a TCC with no claims' do
+      expect(tcc.has_pending_claims?).to be false
+    end
+
+    it '#has_pending_claims? is true with a pending test-scope claim' do
+      create(:claim, :test_scope, computer: computer, commit: commit,
+                                  test_case_commit: tcc)
+      expect(tcc.has_pending_claims?).to be true
+    end
+
+    it '#has_pending_claims? is false when the only claim has been fulfilled' do
+      create(:claim, :test_scope, :fulfilled,
+             computer: computer, commit: commit, test_case_commit: tcc)
+      expect(tcc.has_pending_claims?).to be false
+    end
+
+    it '#pending? is true when status is -1 and there is a pending claim' do
+      create(:claim, :test_scope, computer: computer, commit: commit,
+                                  test_case_commit: tcc)
+      expect(tcc.pending?).to be true
+    end
+
+    it "#pending? is false when status is -1 and there's no claim" do
+      expect(tcc.pending?).to be false
+    end
+
+    it '#pending? is false once the TCC has any non-untested status' do
+      # Mid-run: a test-scope claim is out AND a passing instance has
+      # already landed. The TCC's status flips to passing(=0) and
+      # #pending? reads as false even though the claim row is still
+      # pending — the test no longer needs work.
+      create(:claim, :test_scope, computer: computer, commit: commit,
+                                  test_case_commit: tcc)
+      sub = create(:submission, commit: commit, computer: computer)
+      create(:test_instance, commit: commit, computer: computer,
+                             test_case: test_case, test_case_commit: tcc,
+                             submission: sub, passed: true)
+      tcc.update_status
+      tcc.save!
+      expect(tcc.pending?).to be false
     end
   end
 end

--- a/spec/requests/api/v1/claims_spec.rb
+++ b/spec/requests/api/v1/claims_spec.rb
@@ -1,0 +1,180 @@
+require 'rails_helper'
+
+# Phase B request specs for the claim-creation endpoint
+# (docs/dispatcher-and-claims.md). Authentication mirrors the
+# legacy submissions endpoint exactly so mesa_test reuses its
+# existing credential plumbing; the request-body shape is new and
+# nested under `submitter:` + `claim:` to leave room for the
+# dispatcher endpoint that follows in Phase C.
+RSpec.describe 'POST /api/v1/claims', type: :request do
+  let(:user) do
+    create(:user, password: 'pw-12345678',
+                  password_confirmation: 'pw-12345678')
+  end
+  let(:computer) { create(:computer, user: user) }
+  let(:commit)   { create(:commit) }
+  let(:test_case) do
+    create(:test_case, name: 'wd_planetary_companion', module: 'binary')
+  end
+  let(:tcc)      { create(:test_case_commit, commit: commit, test_case: test_case) }
+
+  let(:valid_submitter) do
+    { email: user.email, password: 'pw-12345678', computer: computer.name }
+  end
+
+  describe 'build scope' do
+    let(:body) do
+      {
+        submitter: valid_submitter,
+        claim: {
+          commit_sha: commit.sha,
+          scope: 'build',
+          use_full_inlists: true
+        }
+      }
+    end
+
+    it 'creates a pending build-scope claim and returns id + expires_at' do
+      expect { post '/api/v1/claims', params: body, as: :json }
+        .to change(Claim, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json).to have_key('claim_id')
+      expect(json).to have_key('expires_at')
+
+      claim = Claim.find(json['claim_id'])
+      expect(claim.scope).to eq('build')
+      expect(claim.status).to eq('pending')
+      expect(claim.computer).to eq(computer)
+      expect(claim.commit).to eq(commit)
+      expect(claim.test_case_commit).to be_nil
+      expect(claim.use_full_inlists).to be true
+      expect(claim.expires_at).to be_within(5.seconds).of(15.minutes.from_now)
+    end
+  end
+
+  describe 'test scope' do
+    let(:body) do
+      {
+        submitter: valid_submitter,
+        claim: {
+          commit_sha: commit.sha,
+          scope: 'test',
+          test_case_module: tcc.test_case.module,
+          test_case_name:   tcc.test_case.name
+        }
+      }
+    end
+
+    it 'creates a pending test-scope claim linked to the matching TCC' do
+      # Pre-load the TCC to make sure it's resolvable by the lookup
+      tcc
+
+      expect { post '/api/v1/claims', params: body, as: :json }
+        .to change(Claim, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      claim = Claim.last
+      expect(claim.scope).to eq('test')
+      expect(claim.test_case_commit).to eq(tcc)
+      expect(claim.expires_at).to be_within(5.seconds).of(12.hours.from_now)
+    end
+
+    it 'echoes dispatched_at when the request supplies one' do
+      tcc
+      dispatched_at = '2026-05-28T10:00:00Z'
+      post '/api/v1/claims',
+           params: body.deep_merge(claim: { dispatched_at: dispatched_at }),
+           as: :json
+
+      expect(response).to have_http_status(:created)
+      claim = Claim.last
+      expect(claim.dispatched_at).to be_within(1.second)
+        .of(Time.zone.parse(dispatched_at))
+    end
+
+    it 'returns 404 when the test case does not exist on this commit' do
+      tcc
+      post '/api/v1/claims',
+           params: body.deep_merge(claim: { test_case_name: 'nope_not_here' }),
+           as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body)).to have_key('error')
+      expect(Claim.count).to eq(0)
+    end
+
+    it 'rejects test-scope claims missing the test_case_module/name pair' do
+      post '/api/v1/claims',
+           params: { submitter: valid_submitter,
+                     claim: { commit_sha: commit.sha, scope: 'test' } },
+           as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)['error']).to match(/test_case_/)
+      expect(Claim.count).to eq(0)
+    end
+  end
+
+  describe 'validation failures' do
+    it 'rejects an unknown scope' do
+      post '/api/v1/claims', params: {
+        submitter: valid_submitter,
+        claim: { commit_sha: commit.sha, scope: 'audit' }
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)['error']).to match(/scope/i)
+      expect(Claim.count).to eq(0)
+    end
+
+    it 'returns 404 for an unknown commit SHA' do
+      post '/api/v1/claims', params: {
+        submitter: valid_submitter,
+        claim: { commit_sha: 'deadbeef' * 5, scope: 'build' }
+      }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(Claim.count).to eq(0)
+    end
+  end
+
+  describe 'authentication failures' do
+    it 'rejects an unknown user' do
+      post '/api/v1/claims', params: {
+        submitter: { email: 'nope@example.com', password: 'pw',
+                     computer: computer.name },
+        claim: { commit_sha: commit.sha, scope: 'build' }
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)['error']).to match(/Invalid e-mail/)
+      expect(Claim.count).to eq(0)
+    end
+
+    it 'rejects a wrong password' do
+      post '/api/v1/claims', params: {
+        submitter: valid_submitter.merge(password: 'wrong'),
+        claim: { commit_sha: commit.sha, scope: 'build' }
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)['error']).to match(/Invalid e-mail/)
+    end
+
+    it "rejects a computer the authenticated user doesn't own" do
+      other_user = create(:user)
+      other_computer = create(:computer, user: other_user, name: 'other-host')
+
+      post '/api/v1/claims', params: {
+        submitter: valid_submitter.merge(computer: other_computer.name),
+        claim: { commit_sha: commit.sha, scope: 'build' }
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)['error']).to match(/doesn't control/)
+      expect(Claim.count).to eq(0)
+    end
+  end
+end

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -110,6 +110,85 @@ RSpec.describe 'Submissions API', type: :request do
     end
   end
 
+  # Phase B of docs/dispatcher-and-claims.md: a submission that
+# carries a `claim:` block in the request payload flips the
+  # referenced claim to `fulfilled`. Backwards-compatible — old
+  # mesa_test versions that don't send the block continue to work.
+  describe 'POST /submissions/create.json with a claim:' do
+    let(:user) do
+      create(:user, password: 'pw-12345678',
+                    password_confirmation: 'pw-12345678')
+    end
+    let(:computer) { create(:computer, user: user) }
+    let(:branch)   { create(:branch, name: 'main') }
+    let(:commit) do
+      c = create(:commit)
+      BranchMembership.create!(branch: branch, commit: c)
+      c
+    end
+    let(:valid_submitter) do
+      { email: user.email, password: 'pw-12345678', computer: computer.name }
+    end
+    let(:valid_commit) do
+      { sha: commit.sha, entire: false, empty: true, compiled: true,
+        compiler: 'gfortran', compiler_version: '13.2.0',
+        sdk_version: '23.7.3', math_backend: 'OpenBLAS' }
+    end
+
+    it 'fulfills a pending claim when claim.id is supplied' do
+      claim = create(:claim, computer: computer, commit: commit,
+                             expires_at: 10.minutes.from_now)
+      post '/submissions/create.json', params: {
+        submitter: valid_submitter,
+        commit: valid_commit,
+        claim: { id: claim.id,
+                 started_at: '2026-05-28T10:00:00Z',
+                 use_fpe: true }
+      }, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(claim.reload.status).to eq('fulfilled')
+      expect(claim.fulfilled_at).to be_within(2.seconds).of(Time.current)
+
+      submission = Submission.last
+      expect(submission.claim_id).to eq(claim.id)
+      expect(submission.use_fpe).to be true
+      expect(submission.started_at).to be_within(1.second)
+        .of(Time.zone.parse('2026-05-28T10:00:00Z'))
+    end
+
+    it 'reactivates an already-expired claim (late submission)' do
+      # A test that took longer than the 12h TTL: the sweeper flipped
+      # the claim to `expired`, but when the submission finally
+      # arrives we should still credit it.
+      claim = create(:claim, :expired,
+                     computer: computer, commit: commit)
+      post '/submissions/create.json', params: {
+        submitter: valid_submitter,
+        commit: valid_commit,
+        claim: { id: claim.id }
+      }, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(claim.reload.status).to eq('fulfilled')
+      expect(claim.fulfilled_at).to be_within(2.seconds).of(Time.current)
+    end
+
+    it 'is a no-op when the submission carries no claim block (legacy client)' do
+      pre_claim = create(:claim, computer: computer, commit: commit)
+
+      post '/submissions/create.json', params: {
+        submitter: valid_submitter,
+        commit: valid_commit
+      }, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(pre_claim.reload.status).to eq('pending')
+      expect(Submission.last.claim_id).to be_nil
+    end
+
+  end
+
   describe 'GET /submissions/request_commit.json' do
     let(:user) { create(:user, password: 'pw-12345678', password_confirmation: 'pw-12345678') }
     let(:computer) { create(:computer, user: user) }

--- a/spec/services/commit_message_flags_spec.rb
+++ b/spec/services/commit_message_flags_spec.rb
@@ -1,0 +1,172 @@
+require 'rails_helper'
+
+# CommitMessageFlags parses the four CI directive flags out of a
+# commit message body. Called from Commit.hash_from_github at
+# ingest, so every column it returns must agree with what the
+# legacy Commit#ci_*? predicates report on the same message — the
+# Postgres backfill in the migration also derives from the same
+# regex shapes, so this spec doubles as the contract for that
+# backfill.
+RSpec.describe CommitMessageFlags do
+  describe '.parse' do
+    let(:default_flags) do
+      {
+        ci_skip: false,
+        wants_full_inlists: false,
+        wants_fpe: false,
+        wants_converge: false
+      }
+    end
+
+    it 'returns all-false for an empty message' do
+      expect(described_class.parse('')).to eq(default_flags)
+    end
+
+    it 'returns all-false for a nil message' do
+      expect(described_class.parse(nil)).to eq(default_flags)
+    end
+
+    it 'returns all-false for a plain message with no directives' do
+      expect(described_class.parse("Fix a typo in the README"))
+        .to eq(default_flags)
+    end
+
+    it 'recognizes [ci skip] in isolation' do
+      result = described_class.parse("Bump version [ci skip]")
+      expect(result[:ci_skip]).to be true
+      expect(result[:wants_full_inlists]).to be false
+      expect(result[:wants_fpe]).to be false
+      expect(result[:wants_converge]).to be false
+    end
+
+    it 'recognizes [ci optional]' do
+      result = described_class.parse("Refactor [ci optional]")
+      expect(result[:wants_full_inlists]).to be true
+      expect(result[:ci_skip]).to be false
+    end
+
+    it 'recognizes [ci optional 1234] (with digit count)' do
+      result = described_class.parse("Refactor [ci optional 1234]")
+      expect(result[:wants_full_inlists]).to be true
+    end
+
+    it 'recognizes [ci fpe]' do
+      result = described_class.parse("Fix conv [ci fpe]")
+      expect(result[:wants_fpe]).to be true
+    end
+
+    it 'recognizes [ci converge]' do
+      result = described_class.parse("Tune solver [ci converge]")
+      expect(result[:wants_converge]).to be true
+    end
+
+    it 'recognizes multiple directives in the same message' do
+      result = described_class.parse("Big change [ci fpe] [ci converge]")
+      expect(result[:wants_fpe]).to be true
+      expect(result[:wants_converge]).to be true
+      expect(result[:wants_full_inlists]).to be false
+      expect(result[:ci_skip]).to be false
+    end
+
+    it 'suppresses ci_skip when ci optional also appears' do
+      # Merge commits that fold a `[ci skip]` PR into something that
+      # asked for full inlists shouldn't skip testing — the optional
+      # directive wins.
+      result = described_class.parse("Merge: tidy [ci skip] [ci optional]")
+      expect(result[:ci_skip]).to be false
+      expect(result[:wants_full_inlists]).to be true
+    end
+
+    it 'suppresses ci_skip when ci fpe also appears' do
+      result = described_class.parse("Merge: tidy [ci skip] [ci fpe]")
+      expect(result[:ci_skip]).to be false
+      expect(result[:wants_fpe]).to be true
+    end
+
+    it 'does NOT suppress ci_skip when only ci converge accompanies it' do
+      # Matches the legacy behavior in Commit#ci_skip? — `[ci converge]`
+      # is not part of the suppression set.
+      result = described_class.parse("Tidy [ci skip] [ci converge]")
+      expect(result[:ci_skip]).to be true
+      expect(result[:wants_converge]).to be true
+    end
+
+    it 'tolerates extra whitespace inside the brackets' do
+      result = described_class.parse("Whitespace [  ci   skip  ]")
+      expect(result[:ci_skip]).to be true
+    end
+
+    it 'tolerates extra whitespace in [ci optional N]' do
+      result = described_class.parse("Long [ ci   optional   42 ]")
+      expect(result[:wants_full_inlists]).to be true
+    end
+
+    it 'is case-sensitive (matches the legacy regex behavior)' do
+      # The legacy Commit#ci_skip? was case-sensitive on `ci skip`;
+      # preserve that — if MESA developers ever need case-insensitive,
+      # it's a deliberate change.
+      expect(described_class.parse("[CI SKIP]")[:ci_skip]).to be false
+    end
+
+    it 'ignores [ci skip] inside an unrelated word' do
+      # Bracketed form is the only one recognized; bare "ci skip" in
+      # prose shouldn't trigger.
+      expect(described_class.parse("we should ci skip this")[:ci_skip])
+        .to be false
+    end
+
+    describe 'first-line restriction' do
+      # MESA convention places directives in the subject line of
+      # the commit they apply to. Squash/merge commits routinely
+      # include each squashed commit's subject in the body — if we
+      # scanned the whole message we'd inherit every directive
+      # from every constituent commit, which is exactly the
+      # opposite of what the author intended.
+      it 'ignores [ci skip] that appears only in the message body' do
+        msg = "docs: Document MESA branching model\n\n" \
+              "Misc cleanup [ci skip]\n"
+        result = described_class.parse(msg)
+        expect(result[:ci_skip]).to be false
+      end
+
+      it 'ignores [ci fpe] / [ci optional] / [ci converge] in the body' do
+        msg = "Refactor public API\n\n" \
+              "* Tighten ABI [ci fpe]\n" \
+              "* New solver path [ci optional]\n" \
+              "* Tune step ctrl [ci converge]\n"
+        result = described_class.parse(msg)
+        expect(result[:wants_fpe]).to be false
+        expect(result[:wants_full_inlists]).to be false
+        expect(result[:wants_converge]).to be false
+      end
+
+      it 'still recognizes a directive on the first line of a multi-line message' do
+        msg = "Fix conv [ci fpe]\n\n" \
+              "Lots of further detail in the body that doesn't matter."
+        result = described_class.parse(msg)
+        expect(result[:wants_fpe]).to be true
+      end
+
+      it 'handles squash/merge bodies that bundle many subject lines' do
+        msg = "Merge feature-X (#42)\n\n" \
+              "* Tidy [ci skip]\n" \
+              "* Solver swap [ci fpe]\n" \
+              "* RTI tune [ci converge]\n" \
+              "* All-inlists pass [ci optional]\n"
+        result = described_class.parse(msg)
+        expect(result).to eq(
+          ci_skip: false,
+          wants_full_inlists: false,
+          wants_fpe: false,
+          wants_converge: false
+        )
+      end
+
+      it 'recognizes a directive only on the first line, even with CRLF endings' do
+        msg = "Refactor [ci optional]\r\nfollow-on body\r\n"
+        result = described_class.parse(msg)
+        expect(result[:wants_full_inlists]).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Lands the data foundation and the claim creation/fulfillment lifecycle for the dispatcher + claims feature described in [`docs/dispatcher-and-claims.md`](docs/dispatcher-and-claims.md). Phase C (dispatcher endpoint) and Phase D (mesa_test client work) are still upcoming; this PR is shippable on its own and **dormant until those land**.

## What's in

**Phase A — schema and CI flag parsing** (commit \`ebf04bc\`)
- \`claims\` table with FKs, composite-status indexes, partial pending-\`expires_at\` index, and a \`claims_scope_fk_coherence\` CHECK constraint.
- Boolean + datetime flag columns on \`commits\` (\`ci_skip\`, \`wants_full_inlists\`, \`wants_fpe\`, \`wants_converge\`, plus \`*_satisfied_at\` companions), populated at ingest by a new \`CommitMessageFlags.parse\` module wired into \`Commit.hash_from_github\`. **Scans only the first line of the commit message** so squash/merge bodies don't inherit every constituent commit's directive.
- Three \`use_*\` columns and a nullable \`claim_id\` FK on \`submissions\`.
- Migration backfills the four flag columns on all existing commits via Postgres regex. Verified row-for-row against the parser on the 10,087-commit prod snapshot: **zero mismatches.**
- \`Commit#ci_*?\` predicates rewritten as thin pass-throughs to the new columns; identical answers via the backfill.

**Phase B — endpoint, sweeper, fulfillment** (commit \`2ae1604\`)
- \`POST /api/v1/claims\` — new endpoint at the start of a v1 API namespace. Auth mirrors \`SubmissionsController\` (submitter block, bcrypt-verified, computer scoped to user). Build claims expire in 15 min; test claims in 12 h. Test-scope claims look up the matching TCC by (module, name).
- \`Claim#fulfill!\` + \`Claim.sweep_expired!\` + \`rake claims:sweep\` — bulk UPDATE backed by the partial index, exposed for the eventual Solid Queue recurring job (see [#98](https://github.com/MESAHub/MESATestHub/pull/98)).
- Submissions endpoint accepts an optional \`claim:\` block (\`id\`, \`started_at\`, \`use_*\` flags) and an \`after_create_commit :fulfill_claim\` on Submission flips the matching claim to fulfilled. **Backwards-compatible** — legacy mesa_test versions that don't send the block work unchanged.

**Phase B (extended) — \"pending\" wired into aggregations** (commit \`5c7f4a9\`)
- \`Commit#has_pending_claims?\` + matching \`TestCaseCommit#has_pending_claims?\` / \`#pending?\` predicates with pre-filtered \`pending_claims\` associations.
- \`CommitState#tests_status\` keys \`:pending\` / \`:not_run\` off \`has_pending_claims?\`, not on \"TCC has no submissions.\"
- \`CommitState#commit_state\` row-classification loop gates the \`no_data → pending_tests\` fallback on real claim presence.
- \`commits#index\` extends its eager-load to keep query count flat across 25 rows.

## Risk and rollout

The schema migration is **metadata-only on Postgres 18** (Railway's version) for all column adds, plus a single backfill UPDATE on ~10k commits (~0.3s locally, well inside Railway's deploy-restart envelope).

**One user-visible behavior change** worth noting: \`tests_status\`'s \`:pending\` / \`:not_run\` distinction now requires real claim presence. **Until Phase D ships mesa_test client work, no commits will ever read as \`:pending\`.** That means:
- The hero \"Pending\" tile on every commit page reads \`0\` instead of \"number of untested TCCs\"
- The pending banner stops firing on fresh commits
- Subway map colors are unchanged (both \`:pending\` and \`:not_run\` render gray; only \`:pending_partial\` is blue)

This corrects the existing leaky proxy — \"fresh commit looks pending\" was never accurate. The tiles light up correctly once Phase D ships real claim data.

Everything else is dormant:
- \`POST /api/v1/claims\` is a new route; no client knows it exists yet
- \`claims:sweep\` rake task isn't wired to cron (the SQ migration in [#98](https://github.com/MESAHub/MESATestHub/pull/98) covers that)
- The submissions endpoint extension is opt-in via the new \`claim:\` payload key

## Test plan

- [x] Full RSpec suite green (421 examples, 0 failures; +85 new specs across the three commits)
- [x] Migration rollback + re-migrate tested locally
- [x] Backfill verified row-for-row against the parser on the 10,087-commit prod snapshot
- [x] \`rake claims:sweep\` smoke-tested against the dev DB
- [ ] After merge: monitor production deploy logs for the migration timing