### PR TITLE
Adopt Solid Queue for recurring jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,5 @@ end
 group :test do
   gem 'database_cleaner'
 end
+
+gem "solid_queue", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -145,6 +147,9 @@ GEM
     faraday-retry (2.4.0)
       faraday (~> 2.0)
     ffi (1.16.2)
+    fugit (1.12.2)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     get_process_mem (0.2.7)
       ffi (~> 1.0)
     github_webhook (1.4.2)
@@ -273,6 +278,7 @@ GEM
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)
       puma (>= 2.7)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-attack (6.7.0)
@@ -362,6 +368,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    solid_queue (1.4.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (>= 1.3.1)
+      fugit (~> 1.11)
+      railties (>= 7.1)
+      thor (>= 1.3.1)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -461,6 +474,7 @@ DEPENDENCIES
   rexml (>= 3.3.9)
   rspec-rails
   selenium-webdriver
+  solid_queue (~> 1.4)
   sprockets-rails
   stimulus-rails (~> 1.3)
   tailwindcss-rails (~> 4.0)

--- a/app/jobs/claim_sweeper_job.rb
+++ b/app/jobs/claim_sweeper_job.rb
@@ -1,0 +1,13 @@
+class ClaimSweeperJob < ApplicationJob
+  queue_as :default
+
+  # Forward-transition pending claims past their expires_at to
+  # expired. Fired every ~5 min from config/recurring.yml so the
+  # commits-index "pending" tile stays wall-clock-accurate. Cheap:
+  # one indexed UPDATE backed by index_claims_on_expires_at_pending.
+  # The rake task claims:sweep remains as the manual/debugging entry
+  # point. See docs/dispatcher-and-claims.md.
+  def perform
+    Claim.sweep_expired!
+  end
+end

--- a/app/jobs/morning_mailer_job.rb
+++ b/app/jobs/morning_mailer_job.rb
@@ -1,0 +1,18 @@
+class MorningMailerJob < ApplicationJob
+  queue_as :default
+
+  # Daily mesa-developers digest. Fired twice in UTC (12:00 + 13:00)
+  # from config/recurring.yml so it lands at 08:00 US Eastern across
+  # the DST boundary; the off-hour fire short-circuits here. Same
+  # guard the old morning_mailer:daily rake task carried. Pass
+  # force: true to send regardless of the local clock.
+  #
+  # Uses deliver_later so a transient Resend failure becomes a queued
+  # mailer retry rather than a missed digest day.
+  def perform(force: false)
+    eastern_hour = Time.now.in_time_zone('America/New_York').hour
+    return if eastern_hour != 8 && !force
+
+    MorningMailer.daily.deliver_later
+  end
+end

--- a/bin/jobs
+++ b/bin/jobs
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+require "solid_queue/cli"
+
+SolidQueue::Cli.start(ARGV)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,8 +71,11 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  # Use Solid Queue for Active Job. The solid_queue_* tables live in the
+  # primary database (no separate queue DB), so there's no connects_to
+  # override — Solid Queue uses the default connection. See
+  # docs/solid-queue-migration.md.
+  config.active_job.queue_adapter = :solid_queue
   # config.active_job.queue_name_prefix = "mesa_test_hub_production"
 
   config.action_mailer.perform_caching = false

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -33,3 +33,10 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+# Run Solid Queue's supervisor (workers + recurring scheduler) inside
+# this Puma process instead of as a separate Railway service. Gated on
+# an env var so dev/test `bin/rails server` never starts background
+# processing; production opts in with SOLID_QUEUE_IN_PUMA=true. See
+# docs/solid-queue-migration.md.
+plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"] == "true"

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,0 +1,18 @@
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 0.1
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,0 +1,26 @@
+# Recurring schedules for Solid Queue's scheduler. These replace the
+# separate Railway cron services that previously booted Rails once per
+# fire. See docs/solid-queue-migration.md.
+#
+# Schedules are evaluated in UTC. The morning mailer fires twice (12:00
+# and 13:00 UTC) so it lands at 08:00 US Eastern across the DST
+# boundary; MorningMailerJob short-circuits on the off-hour fire — the
+# same workaround the old cron service used.
+#
+# Only the production environment runs recurring tasks; development
+# stays on the :async adapter and test on :test, so neither has a
+# scheduler.
+
+production:
+  morning_mailer:
+    class: MorningMailerJob
+    schedule: "0 12,13 * * *"
+  branch_reconcile:
+    class: BranchReconcileJob
+    schedule: "*/15 * * * *"
+  claim_sweep:
+    class: ClaimSweeperJob
+    schedule: "*/5 * * * *"
+  clear_solid_queue_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    schedule: every hour at minute 12

--- a/db/migrate/20260528195909_create_solid_queue_tables.rb
+++ b/db/migrate/20260528195909_create_solid_queue_tables.rb
@@ -1,0 +1,131 @@
+class CreateSolidQueueTables < ActiveRecord::Migration[8.0]
+  def change
+    create_table "solid_queue_blocked_executions", force: :cascade do |t|
+      t.bigint "job_id", null: false
+      t.string "queue_name", null: false
+      t.integer "priority", default: 0, null: false
+      t.string "concurrency_key", null: false
+      t.datetime "expires_at", null: false
+      t.datetime "created_at", null: false
+      t.index [ "concurrency_key", "priority", "job_id" ], name: "index_solid_queue_blocked_executions_for_release"
+      t.index [ "expires_at", "concurrency_key" ], name: "index_solid_queue_blocked_executions_for_maintenance"
+      t.index [ "job_id" ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+    end
+
+    create_table "solid_queue_claimed_executions", force: :cascade do |t|
+      t.bigint "job_id", null: false
+      t.bigint "process_id"
+      t.datetime "created_at", null: false
+      t.index [ "job_id" ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+      t.index [ "process_id", "job_id" ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+    end
+
+    create_table "solid_queue_failed_executions", force: :cascade do |t|
+      t.bigint "job_id", null: false
+      t.text "error"
+      t.datetime "created_at", null: false
+      t.index [ "job_id" ], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+    end
+
+    create_table "solid_queue_jobs", force: :cascade do |t|
+      t.string "queue_name", null: false
+      t.string "class_name", null: false
+      t.text "arguments"
+      t.integer "priority", default: 0, null: false
+      t.string "active_job_id"
+      t.datetime "scheduled_at"
+      t.datetime "finished_at"
+      t.string "concurrency_key"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
+      t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
+      t.index [ "finished_at" ], name: "index_solid_queue_jobs_on_finished_at"
+      t.index [ "queue_name", "finished_at" ], name: "index_solid_queue_jobs_for_filtering"
+      t.index [ "scheduled_at", "finished_at" ], name: "index_solid_queue_jobs_for_alerting"
+    end
+
+    create_table "solid_queue_pauses", force: :cascade do |t|
+      t.string "queue_name", null: false
+      t.datetime "created_at", null: false
+      t.index [ "queue_name" ], name: "index_solid_queue_pauses_on_queue_name", unique: true
+    end
+
+    create_table "solid_queue_processes", force: :cascade do |t|
+      t.string "kind", null: false
+      t.datetime "last_heartbeat_at", null: false
+      t.bigint "supervisor_id"
+      t.integer "pid", null: false
+      t.string "hostname"
+      t.text "metadata"
+      t.datetime "created_at", null: false
+      t.string "name", null: false
+      t.index [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
+      t.index [ "name", "supervisor_id" ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+      t.index [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
+    end
+
+    create_table "solid_queue_ready_executions", force: :cascade do |t|
+      t.bigint "job_id", null: false
+      t.string "queue_name", null: false
+      t.integer "priority", default: 0, null: false
+      t.datetime "created_at", null: false
+      t.index [ "job_id" ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+      t.index [ "priority", "job_id" ], name: "index_solid_queue_poll_all"
+      t.index [ "queue_name", "priority", "job_id" ], name: "index_solid_queue_poll_by_queue"
+    end
+
+    create_table "solid_queue_recurring_executions", force: :cascade do |t|
+      t.bigint "job_id", null: false
+      t.string "task_key", null: false
+      t.datetime "run_at", null: false
+      t.datetime "created_at", null: false
+      t.index [ "job_id" ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+      t.index [ "task_key", "run_at" ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+    end
+
+    create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+      t.string "key", null: false
+      t.string "schedule", null: false
+      t.string "command", limit: 2048
+      t.string "class_name"
+      t.text "arguments"
+      t.string "queue_name"
+      t.integer "priority", default: 0
+      t.boolean "static", default: true, null: false
+      t.text "description"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index [ "key" ], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+      t.index [ "static" ], name: "index_solid_queue_recurring_tasks_on_static"
+    end
+
+    create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+      t.bigint "job_id", null: false
+      t.string "queue_name", null: false
+      t.integer "priority", default: 0, null: false
+      t.datetime "scheduled_at", null: false
+      t.datetime "created_at", null: false
+      t.index [ "job_id" ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+      t.index [ "scheduled_at", "priority", "job_id" ], name: "index_solid_queue_dispatch_all"
+    end
+
+    create_table "solid_queue_semaphores", force: :cascade do |t|
+      t.string "key", null: false
+      t.integer "value", default: 1, null: false
+      t.datetime "expires_at", null: false
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index [ "expires_at" ], name: "index_solid_queue_semaphores_on_expires_at"
+      t.index [ "key", "value" ], name: "index_solid_queue_semaphores_on_key_and_value"
+      t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true
+    end
+
+    add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+    add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+    add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+    add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+    add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+    add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_28_150845) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_28_195909) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -137,6 +137,127 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_28_150845) do
     t.index ["test_instance_id"], name: "index_instance_inlists_on_test_instance_id"
   end
 
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
   create_table "submissions", force: :cascade do |t|
     t.boolean "compiled"
     t.boolean "entire"
@@ -255,6 +376,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_28_150845) do
   add_foreign_key "computers", "users", on_delete: :cascade
   add_foreign_key "inlist_data", "instance_inlists"
   add_foreign_key "instance_inlists", "test_instances"
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "submissions", "claims"
   add_foreign_key "submissions", "commits"
   add_foreign_key "submissions", "computers"

--- a/docs/morning-mailer.md
+++ b/docs/morning-mailer.md
@@ -32,8 +32,16 @@ that replaced the SVN-era `Version` rows.
   template inside the modern app layout so the user can navigate
   away.  Accepts `?date=YYYY-MM-DD` for historical previews and
   `?refresh=1` to bust the 24-hour cache.
+- **[`app/jobs/morning_mailer_job.rb`](../app/jobs/morning_mailer_job.rb)**
+  `MorningMailerJob` — the production driver. A Solid Queue
+  recurring task (see [`config/recurring.yml`](../config/recurring.yml))
+  fires it twice in UTC; the job carries the 8-AM-Eastern guard and
+  calls `MorningMailer.daily.deliver_later`. See
+  [`docs/solid-queue-migration.md`](solid-queue-migration.md).
 - **[`lib/tasks/morning_mailer.rake`](../lib/tasks/morning_mailer.rake)**
-  `morning_mailer:daily` rake task — what cron invokes.
+  `morning_mailer:daily` rake task — the manual / debugging entry
+  point (`FORCE=1` to send regardless of clock). No longer the
+  scheduled driver.
 
 ## Anomaly detection
 
@@ -78,19 +86,25 @@ SMTP, swapping back is reverting the
 change to set `delivery_method = :smtp` with `smtp_settings`
 pointing at the provider.
 
-### Required env vars (cron service)
+### Required env vars
+
+Since the digest now runs as a Solid Queue recurring job inside the
+**web service's** Puma process (no separate cron service), these
+just need to be present on the web service — most already are:
 
 | Var | Purpose |
 |---|---|
 | `RESEND_API_KEY` | API key from Resend's dashboard. |
-| `DATABASE_URL` | Reference the Railway Postgres service: `${{Postgres.DATABASE_URL}}`. |
-| `SECRET_KEY_BASE` | Required for Rails to boot. Reference the web service's: `${{MESATestHub.SECRET_KEY_BASE}}`. |
-| `GIT_TOKEN` | Optional but recommended — without it, the digest shows "couldn't check" for the release-blocker line. Reference the web service's: `${{MESATestHub.GIT_TOKEN}}`. |
-| `RAILS_ENV` | Set to `production` (gates the `:resend` delivery method — see [`application_mailer.rb`](../app/mailers/application_mailer.rb)). |
-| `TZ` | Set to `America/New_York` so `Time.now` reads Eastern inside the rake task's "is it 8 AM yet?" guard. Note: the Railway cron *scheduler* itself always evaluates in UTC — see the cron section below. |
+| `DATABASE_URL` | The Railway Postgres service. |
+| `SECRET_KEY_BASE` | Required for Rails to boot. |
+| `GIT_TOKEN` | Optional but recommended — without it, the digest shows "couldn't check" for the release-blocker line. |
+| `RAILS_ENV` | `production` (gates the `:resend` delivery method — see [`application_mailer.rb`](../app/mailers/application_mailer.rb)). |
+| `SOLID_QUEUE_IN_PUMA` | `true` — starts Solid Queue's supervisor + scheduler inside Puma so recurring jobs actually fire. See [`config/puma.rb`](../config/puma.rb). |
 
-Old `SMTP_*` env vars from the SMTP era can be removed; they're
-no longer read.
+`MorningMailerJob`'s 8-AM-Eastern guard reads
+`Time.now.in_time_zone('America/New_York')` explicitly, so it does
+**not** depend on a `TZ` env var. Old `SMTP_*` env vars from the
+SMTP era can be removed; they're no longer read.
 
 ### Domain verification in Resend
 
@@ -113,36 +127,43 @@ is unchanged.
 ## Scheduling — 8 AM US Eastern
 
 The intended cadence is **8:00 AM US Eastern Time** every day.
-Railway's cron scheduler evaluates schedules in UTC regardless of
-the service's `TZ` env var, and 8 AM ET moves between 12 UTC (EDT)
-and 13 UTC (EST) twice a year.  To get a stable 8 AM ET delivery
-across DST without manual schedule edits, we fire **twice** in UTC
-and let the rake task itself decide whether it's actually 8 AM
-Eastern.
+Solid Queue's scheduler evaluates `config/recurring.yml` schedules
+in UTC, and 8 AM ET moves between 12 UTC (EDT) and 13 UTC (EST)
+twice a year.  To get a stable 8 AM ET delivery across DST without
+manual schedule edits, we fire **twice** in UTC and let
+`MorningMailerJob` itself decide whether it's actually 8 AM Eastern.
 
-### Railway cron trigger
+### Solid Queue recurring task
 
-On the cron service:
+The digest is now scheduled in-process by Solid Queue, not by a
+separate Railway cron service.  The stanza in
+[`config/recurring.yml`](../config/recurring.yml):
 
-1. **Variables** → set everything in the table above.
-2. **Settings** → set the two fields:
-   - **Cron Schedule**: `0 12,13 * * *` (fires at 12:00 UTC *and* 13:00 UTC)
-   - **Custom Start Command**: `bundle exec rake morning_mailer:daily`
+```yaml
+production:
+  morning_mailer:
+    class: MorningMailerJob
+    schedule: "0 12,13 * * *"
+```
 
-   When a Cron Schedule is set, Railway runs the service as a
-   one-shot job and uses Custom Start Command as the command for
-   each invocation.
-3. `lib/tasks/morning_mailer.rake` checks `Time.now.in_time_zone('America/New_York').hour`
-   on every run and **exits without sending** when the local
-   Eastern hour isn't 8.  Net effect: during EDT (UTC-4) the 12 UTC
-   fire delivers and the 13 UTC fire skips; during EST (UTC-5) the
-   12 UTC fire skips and the 13 UTC fire delivers.  Always 8 AM ET,
-   no DST babysitting.
+fires `MorningMailerJob` at 12:00 UTC *and* 13:00 UTC.  The job's
+`perform` checks `Time.now.in_time_zone('America/New_York').hour`
+and **returns without delivering** when the local Eastern hour
+isn't 8.  Net effect: during EDT (UTC-4) the 12 UTC fire delivers
+and the 13 UTC fire skips; during EST (UTC-5) the 12 UTC fire skips
+and the 13 UTC fire delivers.  Always 8 AM ET, no DST babysitting.
 
-The cron service is a separate Railway service from the web app —
-both deploy from this repo, but only the web service has a public
-domain.  The cron service wakes up at the scheduled time, runs the
-rake task once, and exits.
+The job calls `MorningMailer.daily.deliver_later`, so a transient
+Resend hiccup becomes a queued mailer retry rather than a missed
+digest day.
+
+This runs inside the web service's Puma process (the `solid_queue`
+Puma plugin, gated on `SOLID_QUEUE_IN_PUMA=true` — see
+[`config/puma.rb`](../config/puma.rb) and
+[`docs/solid-queue-migration.md`](solid-queue-migration.md)).  There
+is no longer a dedicated cron service to maintain; deleting the old
+`morning_mailer:daily` Railway cron service is part of the Solid
+Queue migration.
 
 ### Local manual send
 

--- a/docs/solid-queue-migration.md
+++ b/docs/solid-queue-migration.md
@@ -1,10 +1,11 @@
 # Solid Queue adoption
 
-**Status:** planning. Not yet implemented.
-**Branch when implementation starts:** `feature-solid-queue`
-(this doc) → a single PR that lands the adapter switch, the Puma
-plugin, and the move of every existing cron-driven recurring task
-into a `config/recurring.yml` entry.
+**Status:** implemented on `feature-solid-queue`. The adapter
+switch, the Puma plugin, the single-DB migration, and all three
+recurring tasks (`morning_mailer`, `branch_reconcile`,
+`claim_sweep`) landed in one PR. The "synchronous code paths worth
+converting" section below remains a followup backlog.
+**Branch:** `feature-solid-queue` → single PR off `master`.
 
 This document is the design and migration plan for replacing the
 project's growing collection of Railway cron services with a
@@ -12,6 +13,28 @@ single in-Puma Solid Queue supervisor. It also catalogs the
 synchronous code paths that would become noticeably better with
 durable queueing once Solid Queue is in place — those are followups,
 not part of the adoption PR itself.
+
+## What actually shipped (deviations from the plan)
+
+- **Single database, not the Rails 8 generator's default.**
+  `bin/rails solid_queue:install` on Rails 8 assumes a *separate*
+  `queue` database: it writes `config.solid_queue.connects_to =
+  { database: { writing: :queue } }` into `production.rb` and emits
+  a standalone `db/queue_schema.rb` (loaded via a `queue:` entry in
+  `database.yml`) instead of a normal migration. We want the
+  `solid_queue_*` tables in the existing primary DB (see "Queue
+  storage" below), so the `connects_to` line was removed and
+  `db/queue_schema.rb` was rewritten as an ordinary migration
+  (`db/migrate/20260528195909_create_solid_queue_tables.rb`) that
+  lands the tables in the primary schema. `database.yml` stays
+  single-DB.
+- **`claim_sweep` shipped in the same PR**, not rebased on top
+  afterward — the claims schema (PR #99) was already on `master` by
+  the time this work started, so `ClaimSweeperJob` +
+  `config/recurring.yml` entry went in directly.
+- **`bin/jobs`** (the standalone Solid Queue CLI) was left in place
+  from the generator. It's unused in the in-Puma deployment but
+  harmless and handy for ad-hoc local worker runs.
 
 ## Motivation
 

--- a/spec/jobs/claim_sweeper_job_spec.rb
+++ b/spec/jobs/claim_sweeper_job_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe ClaimSweeperJob, type: :job do
+  it 'delegates to Claim.sweep_expired!' do
+    expect(Claim).to receive(:sweep_expired!)
+    described_class.perform_now
+  end
+end

--- a/spec/jobs/morning_mailer_job_spec.rb
+++ b/spec/jobs/morning_mailer_job_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe MorningMailerJob, type: :job do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:message) { instance_double(ActionMailer::MessageDelivery) }
+
+  before { allow(MorningMailer).to receive(:daily).and_return(message) }
+
+  # 2026-05-28 is EDT (UTC-4), so 8 AM Eastern is 12:00 UTC.
+  let(:eight_am_eastern) { Time.utc(2026, 5, 28, 12, 30) }
+  let(:one_pm_eastern)   { Time.utc(2026, 5, 28, 17, 30) }
+
+  context 'when the local clock reads 8 AM Eastern' do
+    it 'enqueues the digest' do
+      travel_to eight_am_eastern do
+        expect(message).to receive(:deliver_later)
+        described_class.perform_now
+      end
+    end
+  end
+
+  context 'when the local clock is not 8 AM Eastern' do
+    it 'short-circuits without delivering' do
+      travel_to one_pm_eastern do
+        expect(MorningMailer).not_to receive(:daily)
+        described_class.perform_now
+      end
+    end
+
+    it 'delivers anyway when forced' do
+      travel_to one_pm_eastern do
+        expect(message).to receive(:deliver_later)
+        described_class.perform_now(force: true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Replaces the growing set of separate Railway cron services with a single in-Puma Solid Queue supervisor (one deploy artifact, one log stream). Implements the plan in [`docs/solid-queue-migration.md`](docs/solid-queue-migration.md).
- Switches the production Active Job adapter to `:solid_queue` (dev stays `:async`, test stays `:test`).
- Keeps `solid_queue_*` tables in the **primary** database. The Rails 8 installer defaults to a separate `queue` DB (`connects_to` + `db/queue_schema.rb`); converted that to an ordinary migration so the tables track in the primary schema and `database.yml` stays single-DB.
- Starts the supervisor + scheduler inside Puma via `plugin :solid_queue`, gated on `SOLID_QUEUE_IN_PUMA` so dev/test never start background processing.
- Moves the two existing cron tasks (`morning_mailer`, `branch_reconcile`) and the new `claim_sweep` into [`config/recurring.yml`](config/recurring.yml). `MorningMailerJob` keeps the 8-AM-Eastern guard and now uses `deliver_later`. Rake tasks remain as manual entry points.

## Out of scope (follow-ups)
The slow synchronous conversions flagged in the migration doc — submission scalar refresh, bulk submission destroy, branch-deletion orphan cleanup — are intentionally deferred to keep this change focused.

## Deploy notes
- Set `SOLID_QUEUE_IN_PUMA=true` on the Railway **web** service.
- After deploy, delete the old `morning_mailer:daily` and `branches:sync` Railway cron services.

## Test plan
- [x] `bundle exec rspec` — 425 examples, 0 failures (4 new job specs)
- [x] Real round-trip through `solid_queue_*` tables on a prod snapshot: enqueue → worker → `Performed`, `finished_at` set, zero failures
- [x] Puma plugin verified: `SOLID_QUEUE_IN_PUMA=true` boots Puma + forks supervisor → dispatcher + worker
- [x] Recurring cron strings validated via fugit (correct next-fire times; `morning_mailer` → 12:00 UTC = 8 AM EDT)