### PR TITLE
Resolve real client IP behind Railway's proxy for rack-attack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,23 @@ helper or partial exists.
   destroyed submission during this walk, so a heavy user can
   produce thousands of after_commit invocations — slow but
   correct. See [`spec/models/user_destroy_cascade_spec.rb`](spec/models/user_destroy_cascade_spec.rb).
+- **Railway hides the real client IP behind a 100.64.0.0/10 proxy.**
+  Railway's edge sits in the RFC 6598 carrier-grade NAT range, which
+  is NOT in Rails' default trusted-proxy list — so `request.remote_ip`
+  (and Rack's raw `req.ip`) resolve to a Railway proxy address
+  (`100.64.x.x`) unless that range is trusted. `config.application.rb`
+  sets `config.action_dispatch.trusted_proxies = [IPAddr.new("100.64.0.0/10")]`
+  so the real client (from `X-Forwarded-For`) is recovered. rack-attack
+  ([`config/initializers/rack_attack.rb`](config/initializers/rack_attack.rb))
+  keys every throttle + the IP-range blocklist off a `Request#remote_ip`
+  override (`env["action_dispatch.remote_ip"]`), NOT `req.ip` — using
+  `req.ip` silently bucketed all anonymous traffic into a few proxy IPs
+  and made the `47.79.*`/`159.138.*`/… scraper blocklist dead. Regression
+  coverage: [`spec/requests/rack_attack_client_ip_spec.rb`](spec/requests/rack_attack_client_ip_spec.rb).
+  (Secondary, not yet addressed: rack-attack counters live in
+  `:memory_store`, so throttle state is per-process and resets on
+  deploy; and `Commit#show` is excluded from lograge, so the heaviest
+  page is invisible in production request logs.)
 
 ## Development commands
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require 'ipaddr'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -14,6 +15,18 @@ module MESATestHub
 
     # Enable rack-attack middleware (configured in initializers/rack_attack.rb)
     config.middleware.use Rack::Attack
+
+    # Railway's edge proxies live in the RFC 6598 carrier-grade NAT range
+    # (100.64.0.0/10), which Rails' default trusted-proxy list does NOT cover.
+    # Without trusting it, every request's remote_ip resolves to a Railway
+    # proxy address (100.64.x.x) instead of the real client, silently breaking
+    # rack-attack's per-IP throttles and IP-range blocklist (which key off
+    # remote_ip). Custom proxies are appended to
+    # ActionDispatch::RemoteIp::TRUSTED_PROXIES, not replacing it. Set here
+    # rather than production.rb so the behavior is identical (and testable)
+    # across environments; the range is private/CGNAT and never a real client
+    # in dev or test, so trusting it everywhere is harmless.
+    config.action_dispatch.trusted_proxies = [IPAddr.new("100.64.0.0/10")]
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,4 +1,17 @@
 class Rack::Attack
+  # Use Rails' computed client IP (ActionDispatch::RemoteIp) rather than the
+  # raw Rack::Request#ip. Behind Railway's proxy the real client only arrives
+  # in X-Forwarded-For; remote_ip strips trusted proxy hops (including the
+  # 100.64.0.0/10 range trusted in application.rb) so throttles and the
+  # IP-range blocklist below key off the actual client instead of a Railway
+  # proxy address. ActionDispatch::RemoteIp runs above Rack::Attack in the
+  # middleware stack, so env['action_dispatch.remote_ip'] is always populated.
+  class Request < ::Rack::Request
+    def remote_ip
+      @remote_ip ||= (env["action_dispatch.remote_ip"] || ip).to_s
+    end
+  end
+
   # Configure cache store (uses Rails cache by default)
   Rack::Attack.cache.store = Rails.cache
 
@@ -24,21 +37,21 @@ class Rack::Attack
     suspicious_ranges = [
       /^47\.79\./, /^159\.138\./, /^119\.(8|12|13)\./, /^189\.1\./
     ]
-    suspicious_ranges.any? { |range| req.ip.match?(range) }
+    suspicious_ranges.any? { |range| req.remote_ip.match?(range) }
   end
 
   # Throttle general requests by IP (only for unauthenticated users)
   # Allow 100 requests per 5 minutes per IP (tightened from 300 to reduce scraper abuse)
   # Authenticated users are safelisted above and bypass this limit
   throttle('req/ip', limit: 100, period: 5.minutes) do |req|
-    req.ip
+    req.remote_ip
   end
 
   # Throttle login attempts by IP (applies to everyone to prevent brute force)
   # Allow 10 login attempts per 20 minutes per IP
   throttle('logins/ip', limit: 10, period: 20.minutes) do |req|
     if req.path == '/login' && req.post?
-      req.ip
+      req.remote_ip
     end
   end
 
@@ -47,7 +60,7 @@ class Rack::Attack
   # Legitimate test result submissions should authenticate
   throttle('api/ip', limit: 100, period: 10.minutes) do |req|
     if req.path.match(/\.(json)$/) || req.path.start_with?('/submissions')
-      req.ip
+      req.remote_ip
     end
   end
 
@@ -55,7 +68,7 @@ class Rack::Attack
   # Allow 30 search requests per 5 minutes per IP  
   throttle('search/ip', limit: 30, period: 5.minutes) do |req|
     if req.path.include?('search')
-      req.ip
+      req.remote_ip
     end
   end
 
@@ -63,7 +76,7 @@ class Rack::Attack
   # This catches scrapers trying invalid test case combinations
   throttle('404s/ip', limit: 5, period: 1.hour) do |req|
     if req.env['PATH_INFO'].to_s.match?(/test_cases/) && !req.session[:user_id].present?
-      req.ip
+      req.remote_ip
     end
   end
 
@@ -115,7 +128,7 @@ class Rack::Attack
     if payload.is_a?(Hash) && payload[:request]
       req = payload[:request]
       match_type = req.env['rack.attack.match_type'] || 'unknown'
-      Rails.logger.warn "[Rack::Attack] #{match_type} #{req.ip} #{req.request_method} #{req.fullpath}"
+      Rails.logger.warn "[Rack::Attack] #{match_type} #{req.remote_ip} #{req.request_method} #{req.fullpath}"
     end
   end
 end

--- a/spec/requests/rack_attack_client_ip_spec.rb
+++ b/spec/requests/rack_attack_client_ip_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+# Regression coverage for the Railway proxy-IP fix.
+#
+# Railway terminates TLS at an edge proxy in the RFC 6598 carrier-grade NAT
+# range (100.64.0.0/10) and forwards the real client in X-Forwarded-For. Rails'
+# default trusted-proxy list does not include that range, so before the fix
+# every request's remote_ip resolved to a Railway proxy address (100.64.x.x).
+# rack-attack keyed its throttles and IP-range blocklist off that, which meant
+# the blocklist could never match a real client and per-IP throttles bucketed
+# the whole internet into a handful of proxy addresses. See PR for context.
+RSpec.describe 'rack-attack client IP resolution behind Railway proxy',
+               type: :request do
+  # Simulate the Railway hop: the TCP peer (REMOTE_ADDR) is a 100.64 proxy,
+  # the real client rides in X-Forwarded-For.
+  let(:railway_proxy) { '100.64.0.5' }
+
+  before { Rack::Attack.cache.store.clear }
+
+  it 'trusts Railway 100.64.0.0/10 so remote_ip is the forwarded client' do
+    expect(Rails.application.config.action_dispatch.trusted_proxies)
+      .to include(an_object_satisfying { |p| p === IPAddr.new('100.64.0.14') })
+  end
+
+  it 'blocks a blocklisted client forwarded through a Railway proxy' do
+    get '/',
+        headers: {
+          'REMOTE_ADDR' => railway_proxy,
+          'X-Forwarded-For' => '47.79.1.1'
+        }
+
+    # The IP-range blocklist (/^47\.79\./) now sees the real client again,
+    # rather than the trusted proxy address, and returns the 403 responder.
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it 'does not block a clean client forwarded through a Railway proxy' do
+    get '/login',
+        headers: {
+          'REMOTE_ADDR' => railway_proxy,
+          'X-Forwarded-For' => '203.0.113.7'
+        }
+
+    # A single request from a non-blocklisted client is below every throttle,
+    # so the public login page renders — anything but the blocklist's 403.
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
## Summary

Recent bot surge sailed past rate limiting because **rack-attack was keying off Railway's proxy IP, not the real client**.

Railway terminates TLS at an edge proxy in the RFC 6598 carrier-grade NAT range (`100.64.0.0/10`), which is **not** in Rails' default trusted-proxy list. So `request.remote_ip` (and Rack's raw `req.ip`) resolved to a Railway proxy address (`100.64.x.x`) instead of the forwarded client. Confirmed from production logs — every IP rack-attack logged was `100.64.0.{5,8,14,37}`.

Consequences:
- The IP-range blocklist (`47.79.*`, `159.138.*`, …) could **never match** a real scraper.
- Per-IP throttles bucketed all anonymous traffic into ~4 proxy addresses, so bots spread across proxies dodged isolation.

## Changes
- `config/application.rb`: trust `100.64.0.0/10` so `remote_ip` recovers the real client from `X-Forwarded-For`. Set app-wide (not production-only) so behavior is identical and testable across environments; the range is private/CGNAT and never a real client in dev/test.
- `config/initializers/rack_attack.rb`: add a `Request#remote_ip` override (`env["action_dispatch.remote_ip"]`) and switch every throttle, the blocklist, and the log line from `req.ip` → `req.remote_ip`.
- `spec/requests/rack_attack_client_ip_spec.rb`: regression coverage — a blocklisted client forwarded through a `100.64` proxy now gets a 403; a clean one renders normally.
- `CLAUDE.md`: document the gotcha.

## Known follow-ups (not in this PR)
- rack-attack counters live in `:memory_store` → per-process, reset on deploy. Consider a shared store (Solid Cache).
- `Commit#show` is excluded from lograge and 404s are dropped, so the heaviest page + most scraper 404s are invisible in production logs.

## Test plan
- [x] `bundle exec rspec` — 428 examples, 0 failures
- [x] New spec proves blocklist fires on the forwarded client behind a `100.64` proxy