### PR TITLE
Exempt the submission API from per-IP rate limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,23 @@ helper or partial exists.
   `:memory_store`, so throttle state is per-process and resets on
   deploy; and `Commit#show` is excluded from lograge, so the heaviest
   page is invisible in production request logs.)
+- **The submission API is exempt from the per-IP throttles.** The
+  test client authenticates with `submitter[:email]` +
+  `submitter[:password]` in the JSON body (bcrypt-verified in
+  `SubmissionsController#submission_authenticated?`), NOT a browser
+  session — so the `safelist('allow authenticated users')` (which
+  checks `req.session[:user_id]`) never fires for it. A computer
+  running the MESA suite POSTs one result per test case (hundreds in
+  a burst from one IP), which used to blow past the generic `req/ip`
+  (100/5min) and `api/ip` (100/10min) throttles and return 429s.
+  `rack_attack.rb` now matches any `/submissions`-prefixed path with
+  `SUBMISSION_PATH`, excludes it from both generic throttles, and
+  gives it a generous `submissions/ip` backstop (`SUBMISSION_LIMIT =
+  1000` / 5min) that exists only to bound a pathological flood — the
+  real access control is the credential + computer-ownership check in
+  the controller. Bump `SUBMISSION_LIMIT` if a large NAT'd cluster
+  ever trips it. Regression coverage in
+  [`spec/requests/rack_attack_client_ip_spec.rb`](spec/requests/rack_attack_client_ip_spec.rb).
 
 ## Development commands
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -26,6 +26,21 @@ class Rack::Attack
     req.session[:user_id].present?
   end
 
+  # The test-client submission API authenticates via posted
+  # credentials (submitter[:email] + submitter[:password], bcrypt-
+  # verified in SubmissionsController), NOT a browser session — so the
+  # session safelist above can never see it. A computer running the
+  # MESA suite submits one POST per test case (hundreds in a burst),
+  # which blew past the generic 100-per-window IP throttles even though
+  # every request carries valid credentials. Treat these paths
+  # specially: exempt them from the general req/ip + api/ip throttles
+  # below and give them their own generous backstop. The real access
+  # control is the credential + computer-ownership check in the
+  # controller, not an IP throttle.
+  SUBMISSION_PATH = lambda do |req|
+    req.path.start_with?('/submissions')
+  end
+
   # Block requests from specific IPs that are known bad actors
   # blocklist('block bad actors') do |req|
   #   # Add specific IP addresses here if needed
@@ -42,9 +57,10 @@ class Rack::Attack
 
   # Throttle general requests by IP (only for unauthenticated users)
   # Allow 100 requests per 5 minutes per IP (tightened from 300 to reduce scraper abuse)
-  # Authenticated users are safelisted above and bypass this limit
+  # Authenticated users are safelisted above and bypass this limit.
+  # Credential-authenticated submissions are exempt (see SUBMISSION_PATH).
   throttle('req/ip', limit: 100, period: 5.minutes) do |req|
-    req.remote_ip
+    req.remote_ip unless SUBMISSION_PATH.call(req)
   end
 
   # Throttle login attempts by IP (applies to everyone to prevent brute force)
@@ -55,13 +71,25 @@ class Rack::Attack
     end
   end
 
-  # Throttle API submissions more strictly (only for unauthenticated requests)
-  # Allow 100 API requests per 10 minutes per IP
-  # Legitimate test result submissions should authenticate
+  # Throttle other JSON API traffic by IP. Excludes the submission
+  # endpoints, which carry their own credentials and get the generous
+  # backstop below — keeping them here capped legitimate test clients
+  # at 100 results per 10 minutes.
   throttle('api/ip', limit: 100, period: 10.minutes) do |req|
-    if req.path.match(/\.(json)$/) || req.path.start_with?('/submissions')
+    if req.path.match(/\.(json)$/) && !SUBMISSION_PATH.call(req)
       req.remote_ip
     end
+  end
+
+  # Generous backstop for the credential-authenticated submission API.
+  # Legitimate clients submit one result per test case — hundreds per
+  # run — and a whole compute cluster can sit behind a single NAT'd IP,
+  # so this limit is set well above any realistic burst. It exists only
+  # to bound a pathological flood; actual auth happens in the controller.
+  # Raise SUBMISSION_LIMIT if a large cluster ever legitimately trips it.
+  SUBMISSION_LIMIT = 1000
+  throttle('submissions/ip', limit: SUBMISSION_LIMIT, period: 5.minutes) do |req|
+    req.remote_ip if SUBMISSION_PATH.call(req)
   end
 
   # Throttle searches to prevent abuse (only for unauthenticated users)

--- a/spec/requests/rack_attack_client_ip_spec.rb
+++ b/spec/requests/rack_attack_client_ip_spec.rb
@@ -71,4 +71,30 @@ RSpec.describe 'rack-attack client IP resolution behind Railway proxy',
     # so the public login page renders — anything but the blocklist's 403.
     expect(response).to have_http_status(:ok)
   end
+
+  # Submissions authenticate via posted credentials, not a browser session,
+  # so the "allow authenticated users" safelist can't see them. They must be
+  # exempt from the generic per-IP throttles — a test client submitting one
+  # result per test case fires hundreds of POSTs in a burst from one IP.
+  describe 'credential-authenticated submission API' do
+    let(:client_ip) { '203.0.113.50' }
+
+    def submit
+      post '/submissions/create.json',
+           params: { submitter: { email: 'nobody@example.com',
+                                  password: 'wrong' } },
+           headers: { 'REMOTE_ADDR' => railway_proxy,
+                      'X-Forwarded-For' => client_ip }
+    end
+
+    it 'is not throttled at the generic 100/window IP limit' do
+      # The req/ip throttle caps at 100 per 5 minutes; fire well past it.
+      # None should be rack-attack's 429 — they fail credential auth with
+      # 422, which is the controller talking, not the rate limiter.
+      statuses = Array.new(120) { submit; response.status }
+
+      expect(statuses).not_to include(429)
+      expect(statuses).to all(eq(422))
+    end
+  end
 end


### PR DESCRIPTION
## Problem
Computers submitting many test results in rapid succession were hitting **429 rate-limit errors** — even though every submission is fully authenticated.

The test client (`mesa_test`) authenticates by posting `submitter[:email]` + `submitter[:password]` in the JSON body (bcrypt-verified in `SubmissionsController#submission_authenticated?`), **not** a browser session. So the existing `safelist('allow authenticated users')` — which keys off `req.session[:user_id]` — never matched submission requests. They fell through to the generic per-IP throttles:

- `req/ip` — 100 requests / 5 min (catches everything)
- `api/ip` — 100 requests / 10 min (matched `.json` paths + `/submissions`)

A computer running the MESA suite POSTs **one result per test case** — hundreds in a burst from one IP — so it blew past 100/window routinely.

## Fix
- Add `SUBMISSION_PATH` matching any `/submissions`-prefixed path.
- Exclude it from both `req/ip` and `api/ip`.
- Add a dedicated `submissions/ip` backstop at `SUBMISSION_LIMIT = 1000` / 5 min — generous enough that no realistic burst (including a NAT'd cluster) trips it, while still bounding a pathological flood.

The real access control for submissions is the credential + computer-ownership check in the controller, so an IP throttle added little security on top and was actively blocking legitimate bulk submitters.

## Tests
- New regression test: 120 consecutive submission POSTs from one IP — none returns 429 (they fail credential auth with 422, proving the rate limiter is out of the path).
- `spec/requests` green: 98 examples, 0 failures.

## Notes
- `SUBMISSION_LIMIT` is a named constant — bump it if a large cluster behind a single NAT ever legitimately trips it.
- CLAUDE.md updated with a reality-check bullet documenting the exemption.