### PR TITLE
Bump faraday and concurrent-ruby for security advisories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crass (1.0.6)
     csv (3.3.5)
@@ -136,7 +136,7 @@ GEM
       railties (>= 5.0.0)
     faker (3.2.1)
       i18n (>= 1.8.11, < 2)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger


### PR DESCRIPTION
Patches two high-severity DoS advisories affecting the pinned gem versions.

## Advisories

| Advisory | Gem | Was | Now |
|---|---|---|---|
| [CVE-2026-54297](https://github.com/advisories/GHSA-98m9-hrrm-r99r) — uncontrolled recursion in `NestedParamsEncoder` | faraday | 2.14.2 | 2.14.3 |
| [CVE-2026-54904](https://rubysec.com/advisories/CVE-2026-54904/) — `AtomicReference#update` livelock on `Float::NAN` | concurrent-ruby | 1.3.4 | 1.3.7 |

- **Faraday**: `NestedParamsEncoder` walks a decoded nested query string with no depth cap, so a small deeply-nested payload raises an uncaught `SystemStackError` and kills the worker (CWE-674).
- **concurrent-ruby**: because `NaN == NaN` is false, `compare_and_set` never succeeds and `AtomicReference#update` busy-loops forever once the stored value is `Float::NAN`, causing CPU exhaustion / a permanent hang.

## Exposure

Practical exposure in this app is **low** — both are defense-in-depth patch bumps rather than fixes for a live exploit path:

- Faraday is used only as an HTTP client toward GitHub (via octokit); the app never feeds attacker-controlled query strings into Faraday's nested-query decoding.
- concurrent-ruby is a transitive Rails dependency with no `AtomicReference`/`Float::NAN` usage in app code.

## Change

Patch-level bumps only — the `Gemfile.lock` diff is just the two version lines. Full suite (434 examples) stays green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)