### PR TITLE
Upgrade puma to 7.2.1 for PROXY-protocol advisories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ end
 ruby '3.2.2'
 
 gem 'rails', '~> 8.0.0'
-gem 'puma', '>= 6.4.2'
+gem 'puma', '~> 7.2', '>= 7.2.1'
 gem 'puma_worker_killer'
 gem 'rack', '>= 2.2.14'
 gem 'rack-attack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (6.6.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)
@@ -463,7 +463,7 @@ DEPENDENCIES
   nokogiri (>= 1.18.9)
   octokit (~> 10.0)
   pg
-  puma (>= 6.4.2)
+  puma (~> 7.2, >= 7.2.1)
   puma_worker_killer
   rack (>= 2.2.14)
   rack-attack


### PR DESCRIPTION
Closes the last two **high**-severity Dependabot alerts (#153, #154).

## Advisories

| Advisory | Was | Now |
|---|---|---|
| Puma PROXY Protocol v1 parser allows remote memory exhaustion | 6.6.0 | 7.2.1 |
| Puma PROXY Protocol v1 accepts repeated protocol headers on persistent connections | 6.6.0 | 7.2.1 |

## Exposure

Both bugs live in the **PROXY Protocol v1 parser**, which this deployment does not enable — `config/puma.rb` has no `proxy_protocol` bind, and Railway/Cloudflare forward plain HTTP. So they were **unreachable** here; this bump clears the alerts and keeps puma current.

## Scope control

- Pinned to `~> 7.2, >= 7.2.1` so the resolver stops at 7.x instead of jumping to puma 8.x — one major-version step, not two.
- `puma_worker_killer` only requires `puma >= 2.7`, so it rides along unchanged.

## Verification

Since the request suite runs on Rack::Test (doesn't exercise puma), I booted a **real puma 7.2.1 server** and confirmed it:

- boots (`Puma version: 7.2.1`)
- serves `GET /` → redirects to `/login`, which renders
- runs the rack-attack middleware
- logs no errors

Full suite (434 examples) stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)